### PR TITLE
[round-7] 느슨한 결합, 유연한 확장을 위한 이벤트 처리

### DIFF
--- a/apps/commerce-api/build.gradle.kts
+++ b/apps/commerce-api/build.gradle.kts
@@ -39,6 +39,9 @@ dependencies {
     implementation("io.github.resilience4j:resilience4j-spring-boot3")
     implementation("org.springframework.boot:spring-boot-starter-aop")
 
+    // test - Awaitility for async/eventually assertions
+    testImplementation("org.awaitility:awaitility:4.2.0")
+
 }
 
 // LargeSeeder 실행을 위한 태스크

--- a/apps/commerce-api/src/main/java/com/loopers/CommerceApiApplication.java
+++ b/apps/commerce-api/src/main/java/com/loopers/CommerceApiApplication.java
@@ -6,10 +6,12 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 import java.util.TimeZone;
 
+@EnableAsync
 @EnableScheduling
 @EnableAspectJAutoProxy
 @EnableFeignClients

--- a/apps/commerce-api/src/main/java/com/loopers/application/coupon/CouponProcessor.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/coupon/CouponProcessor.java
@@ -15,6 +15,11 @@ public class CouponProcessor {
     private final UserCouponRepository userCouponRepository;
     private final CouponValidationDomainService couponValidationDomainService;
 
+    public UserCouponModel findByOrderId(Long orderId) {
+        return userCouponRepository.findByOrderId(orderId).orElse(null);
+    }
+
+
     public int applyCouponDiscount(UserId userId, int orderPrice, String couponCode) {
         if (couponCode == null || couponCode.isEmpty()) {
             return orderPrice;
@@ -38,18 +43,18 @@ public class CouponProcessor {
         return orderPrice;
     }
 
-    public void useCoupon(UserId userId, String couponCode) {
+    public void useCoupon(UserId userId, String couponCode, Long orderId) {
         if (couponCode == null || couponCode.isEmpty()) {
             return;
         }
 
         UserCouponModel userCoupon = userCouponRepository.findByUserIdAndCouponCode(userId, couponCode)
                 .orElseThrow(() -> new IllegalArgumentException("사용자에게 해당 쿠폰이 없습니다."));
-        userCoupon.useCoupon(LocalDate.now());
+        userCoupon.useCoupon(LocalDate.now(),orderId);
         userCouponRepository.save(userCoupon);
     }
 
-    public void reserveCoupon(UserId userId, String couponCode) {
+    public void reserveCoupon(UserId userId, String couponCode, Long orderId) {
         if (couponCode == null || couponCode.isEmpty()) {
             return;
         }
@@ -59,7 +64,7 @@ public class CouponProcessor {
         if (userCoupon.getStatus() != UserCoupontStatus.AVAILABLE) {
             throw new IllegalArgumentException("쿠폰이 사용 가능 상태가 아닙니다. 현재 상태: " + userCoupon.getStatus());
         }
-        userCoupon.reserve();
+        userCoupon.reserve(orderId);
         userCouponRepository.save(userCoupon);
     }
 

--- a/apps/commerce-api/src/main/java/com/loopers/application/like/LikeApplicationService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/like/LikeApplicationService.java
@@ -8,6 +8,10 @@ import com.loopers.domain.category.CategoryRepository;
 import com.loopers.domain.like.LikeModel;
 import com.loopers.domain.like.LikeRepository;
 import com.loopers.domain.like.ProductLikeDomainService;
+import com.loopers.domain.like.event.ProductLikePublisher;
+import com.loopers.domain.like.event.ProductLikedEvent;
+import com.loopers.domain.like.event.ProductUnLikePublisher;
+import com.loopers.domain.like.event.ProductUnlikedEvent;
 import com.loopers.domain.product.ProductModel;
 import com.loopers.domain.product.ProductRepository;
 import com.loopers.domain.user.UserId;
@@ -31,6 +35,9 @@ public class LikeApplicationService {
     private final BrandRepository brandRepository;
     private final CategoryRepository categoryRepository;
 
+    private final ProductLikePublisher likeEventPublisher;
+    private final ProductUnLikePublisher unLikeEventPublisher;
+
     /**
      * 사용자가 상품을 좋아요 추가
      */
@@ -46,6 +53,7 @@ public class LikeApplicationService {
         // null이 반환되면 이미 좋아요가 되어 있는 상태이므로 아무 동작도 하지 않음
         if (like != null) {
             likeRepository.save(like);
+            likeEventPublisher.publish(ProductLikedEvent.create(productId, userId));
         }
     }
 
@@ -64,6 +72,7 @@ public class LikeApplicationService {
         // null이 반환되면 이미 좋아요가 취소되어 있는 상태이므로 아무 동작도 하지 않음
         if (like != null) {
             likeRepository.delete(like);
+            unLikeEventPublisher.publish(ProductUnlikedEvent.create(productId, userId));
         }
     }
 

--- a/apps/commerce-api/src/main/java/com/loopers/application/like/LikeCountEventHandler.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/like/LikeCountEventHandler.java
@@ -1,0 +1,59 @@
+package com.loopers.application.like;
+
+
+import com.loopers.domain.like.event.ProductLikedEvent;
+import com.loopers.domain.like.event.ProductUnlikedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class LikeCountEventHandler {
+
+    private final LikeCountProcessor likeCountProcessor;
+    private final UserLikeActionTrackingEventHandler userLikeActionTrackingEventHandler;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleProductLiked(ProductLikedEvent event) {
+        log.info("[LikeEventHandler] 좋아요 이벤트 처리 시작 - ProductId: {}, UserId: {}",
+                event.getProductId(), event.getUserId().getValue());
+
+        try {
+            // 상품 좋아요 수 증가
+            likeCountProcessor.updateProductLikeCount(event.getProductId(), 1);
+
+            log.info("[LikeEventHandler] 좋아요 후속 처리 완료 - ProductId: {}", event.getProductId());
+
+        } catch (Exception e) {
+            log.error("[LikeEventHandler] 좋아요 이벤트 처리 중 예외 발생 - ProductId: {}, Error: {}",
+                    event.getProductId(), e.getMessage(), e);
+
+        }
+    }
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleProductUnliked(ProductUnlikedEvent event) {
+        log.info("[LikeEventHandler] 좋아요 취소 이벤트 처리 시작 - ProductId: {}, UserId: {}",
+                event.getProductId(), event.getUserId().getValue());
+
+        try {
+            // 1. 상품 좋아요 수 감소
+            likeCountProcessor.updateProductLikeCount(event.getProductId(), -1);
+
+            log.info("[LikeEventHandler] 좋아요 취소 후속 처리 완료 - ProductId: {}", event.getProductId());
+
+        } catch (Exception e) {
+            log.error("[LikeEventHandler] 좋아요 취소 이벤트 처리 중 예외 발생 - ProductId: {}, Error: {}",
+                    event.getProductId(), e.getMessage(), e);
+        }
+    }
+
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/like/LikeCountProcessor.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/like/LikeCountProcessor.java
@@ -1,0 +1,43 @@
+package com.loopers.application.like;
+
+import com.loopers.domain.product.ProductModel;
+import com.loopers.domain.product.ProductRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import io.github.resilience4j.retry.annotation.Retry;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class LikeCountProcessor {
+
+    private final ProductRepository productRepository;
+
+
+    @Retry(name = "optimisticLockRetry")
+    @Transactional
+    public void updateProductLikeCount(Long productId, int countDelta) {
+        try {
+            ProductModel product = productRepository.findById(productId)
+                    .orElseThrow(() -> new IllegalArgumentException("상품을 찾을 수 없습니다: " + productId));
+
+            if (countDelta > 0) {
+                product.incrementLikesCount();
+                log.debug("[LikeEventHandler] 좋아요 수 증가 - ProductId: {}, 현재 수: {}",
+                        productId, product.getLikesCount());
+            } else {
+                product.decrementLikesCount();
+                log.debug("[LikeEventHandler] 좋아요 수 감소 - ProductId: {}, 현재 수: {}",
+                        productId, product.getLikesCount());
+            }
+
+            productRepository.save(product);
+
+        } catch (Exception e) {
+            log.error("[LikeEventHandler] 좋아요 수 업데이트 실패 - ProductId: {}, CountDelta: {}, Error: {}",
+                    productId, countDelta, e.getMessage(), e);
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/like/UserLikeActionTrackingEventHandler.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/like/UserLikeActionTrackingEventHandler.java
@@ -1,0 +1,55 @@
+package com.loopers.application.like;
+
+import com.loopers.domain.like.event.ProductLikedEvent;
+import com.loopers.domain.like.event.ProductUnlikedEvent;
+import com.loopers.domain.user.event.UserActionData;
+import com.loopers.domain.user.event.UserActionTrackingPort;
+import com.loopers.domain.user.event.UserActionType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class UserLikeActionTrackingEventHandler {
+
+    private final UserActionTrackingPort userActionTrackingPort;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void trackUserLikeAction(ProductLikedEvent event) {
+        try {
+            UserActionData actionData = UserActionData.create(
+                    event.getUserId(),
+                    UserActionType.PRODUCT_LIKE,
+                    event.getProductId()
+            );
+            userActionTrackingPort.trackUserAction(actionData);
+
+        } catch (Exception e) {
+            log.error("[LikeEventHandler] Like Count 사용자 행동 로깅 실패 - ProductId: {}, UserId: {}, Error: {}",
+                    event.getProductId(), event.getUserId().getValue(), e.getMessage(), e);
+        }
+    }
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void trackUserUnlikeAction(ProductUnlikedEvent event) {
+        try {
+            UserActionData actionData = UserActionData.create(
+                    event.getUserId(),
+                    UserActionType.PRODUCT_UNLIKE,
+                    event.getProductId()
+            );
+            userActionTrackingPort.trackUserAction(actionData);
+
+        } catch (Exception e) {
+            log.error("[LikeEventHandler] UnLike Count 사용자 행동 로깅 실패 - ProductId: {}, UserId: {}, Error: {}",
+                    event.getProductId(), event.getUserId().getValue(), e.getMessage(), e);
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderApplicationService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderApplicationService.java
@@ -1,16 +1,14 @@
 package com.loopers.application.order;
 
-import com.loopers.application.coupon.CouponProcessor;
-import com.loopers.application.point.PointProcessor;
-import com.loopers.application.product.StockDeductionProcessor;
 import com.loopers.application.user.UserValidator;
-import com.loopers.domain.order.Money;
 import com.loopers.domain.order.OrderCreationDomainService;
 import com.loopers.domain.order.OrderItemModel;
 import com.loopers.domain.order.OrderModel;
+import com.loopers.domain.order.event.*;
 import com.loopers.domain.product.ProductModel;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -18,51 +16,48 @@ import java.util.List;
 @RequiredArgsConstructor
 public class OrderApplicationService {
 
-    private final UserValidator userValidator;
+	private final UserValidator userValidator;
 
-    private final OrderItemProductsValidator orderItemProductsValidator;
+	private final OrderItemProductsValidator orderItemProductsValidator;
+	private final OrderPersistenceHandler orderPersistenceHandler;
+	private final OrderCreationDomainService orderCreationDomainService;
+	private final OrderPriceCalculator orderPriceCalculator;
 
-    private final PointProcessor pointProcessor;
+	private final OrderCreatedPublisher orderCreatedPublisher;
+    private final OrderCreatedCouponReservePublisher couponReservePublisher;
+    private final OrderCreatedStockDeductionPublisher stockDeductionPublisher;
 
-    private final StockDeductionProcessor stockDeductionProcessor;
+	/**
+	 * 주문 생성
+	 */
+    @Transactional
+	public OrderInfo createOrder(OrderCommand command) {
+		// 1. 사용자 검증
+		userValidator.validateUserExists(command.userId());
 
-    private final OrderPersistenceHandler orderPersistenceHandler;
+		// 2. 상품 검증 및 조회
+		List<ProductModel> products = orderItemProductsValidator.validateAndGetProducts(command.items());
+		List<OrderItemModel> orderItems = OrderItemCommand.convertToOrderItems(command.items());
 
-    private final CouponProcessor couponProcessor;
+		// 3. 가격 계산
+		int orderPrice = orderCreationDomainService.calculateOrderPrice(orderItems);
+		OrderPricing pricing = orderPriceCalculator.calculate(command.userId(), orderPrice, command.couponCode());
 
-    private final OrderCreationDomainService orderCreationDomainService;
+		// 4. 주문 생성 및 저장 (CREATED 상태)
+		OrderModel order = OrderModel.create(command.userId(), pricing.getFinalAmount(), command.paymentMethod());
+		OrderModel savedOrder = orderPersistenceHandler.saveOrder(order);
 
-    /**
-     * 주문 생성
-     */
-    public OrderInfo createOrder(OrderCommand command) {
-        // 1. 사용자 검증
-        userValidator.validateUserExists(command.userId());
+		// 5. 주문 아이템 저장
+		List<OrderItemModel> savedOrderItems = orderPersistenceHandler.saveOrderItem(savedOrder, orderItems);
 
-        // 2. 상품 검증 및 조회
-        List<ProductModel> products = orderItemProductsValidator.validateAndGetProducts(command.items());
-        List<OrderItemModel> orderItems = OrderItemCommand.convertToOrderItems(command.items());
+		// -- 주문생성 이벤트 발행 --
+        orderCreatedPublisher.publish(OrderCreatedEvent.from(savedOrder));
+        // -- 쿠폰예약 커맨드 발행 --
+        couponReservePublisher.publish(OrderCeatedCouponReserveCommand.create(savedOrder.getId(), savedOrder.getUserId(), command.couponCode()));
+        // -- 재고차감 커맨드 발행 --
+        stockDeductionPublisher.publish(OrderCreatedStockDeductionCommand.create(orderItems));
 
-        // 3. 가격 계산
-        int orderPrice = orderCreationDomainService.calculateOrderPrice(orderItems);
-        int currentProcessingAmount = couponProcessor.applyCouponDiscount(command.userId(), orderPrice, command.couponCode());
-        int usedPoints = pointProcessor.processPointUsage(command.userId(), currentProcessingAmount, command.requestPoint());
-        int finalTotalPrice = currentProcessingAmount - usedPoints;
-
-        // 4. 재고 차감
-        stockDeductionProcessor.deductProductStocks(orderItems);
-
-        // 5. 주문 생성 및 저장 (CREATED 상태) - 저장된 엔티티 사용
-        OrderModel order = OrderModel.create(command.userId(), Money.of(finalTotalPrice), command.couponCode(), command.paymentMethod());
-        OrderModel savedOrder = orderPersistenceHandler.saveOrder(order);
-
-        // 6. 쿠폰 예약
-        couponProcessor.reserveCoupon(command.userId(), command.couponCode());
-
-        // 7. 주문 아이템 저장 - 저장된 엔티티 사용
-        List<OrderItemModel> savedOrderItems = orderPersistenceHandler.saveOrderItem(savedOrder, orderItems);
-
-        return OrderInfo.from(savedOrder, OrderItemInfo.createOrderItemInfos(savedOrderItems, products));
-    }
+		return OrderInfo.from(savedOrder, OrderItemInfo.createOrderItemInfos(savedOrderItems, products));
+	}
 
 } 

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderCommand.java
@@ -1,7 +1,7 @@
 package com.loopers.application.order;
 
-import com.loopers.domain.payment.CardType;
-import com.loopers.domain.payment.PaymentMethod;
+import com.loopers.domain.payment.model.CardType;
+import com.loopers.domain.payment.model.PaymentMethod;
 import com.loopers.domain.user.UserId;
 
 import java.util.List;

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderEventHandler.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderEventHandler.java
@@ -1,0 +1,118 @@
+package com.loopers.application.order;
+
+import com.loopers.application.coupon.CouponProcessor;
+import com.loopers.application.product.StockDeductionProcessor;
+import com.loopers.domain.external.DataPlatformPort;
+import com.loopers.domain.external.DataPlatformResult;
+import com.loopers.domain.order.event.OrderCeatedCouponReserveCommand;
+import com.loopers.domain.order.event.OrderCreatedEvent;
+import com.loopers.domain.order.event.OrderCreatedStockDeductionCommand;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OrderEventHandler {
+
+    private final DataPlatformPort dataPlatformPort;
+    private final CouponProcessor couponProcessor;
+    private final StockDeductionProcessor stockDeductionProcessor;
+
+    /**
+     * 재고 차감 (커맨드)
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    public void processStockDeduction(OrderCreatedStockDeductionCommand command) {
+        if (command.orderItemList() != null && !command.orderItemList().isEmpty()) {
+            try {
+                log.info("[OrderEventHandler] 재고차감 처리 시작 - ");
+                stockDeductionProcessor.deductProductStocks(command.orderItemList());
+                log.info("[OrderEventHandler] 재고차감 처리 완료 - ");
+            } catch (Exception e) {
+                log.error("[OrderEventHandler] 재고차감 처리 실패 - ");
+            }
+        } else {
+            log.debug("[OrderEventHandler] 차감할 재고가 없음");
+        }
+
+    }
+
+    /**
+     * 쿠폰 예약 (커맨드)
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    public void processCouponReserve(OrderCeatedCouponReserveCommand command) {
+        if (command.couponCode() != null && !command.couponCode().isEmpty()) {
+            try {
+                log.info("[OrderEventHandler] 쿠폰 예약 처리 시작 - OrderId: {}, CouponCode: {}",
+                        command.orderId(), command.couponCode());
+
+                couponProcessor.reserveCoupon(command.userId(), command.couponCode(), command.orderId());
+
+                log.info("[OrderEventHandler] 쿠폰 예약 처리 완료 - OrderId: {}, CouponCode: {}",
+                        command.orderId(), command.couponCode());
+
+            } catch (Exception e) {
+                log.error("[OrderEventHandler] 쿠폰 예약 처리 실패 - OrderId: {}, CouponCode: {}, Error: {}",
+                        command.orderId(), command.couponCode(), e.getMessage(), e);
+
+            }
+        } else {
+            log.debug("[OrderEventHandler] 예약할 쿠폰이 없음 - OrderId: {}", command.orderId());
+        }
+    }
+
+    /**
+     * 데이터 플랫폼 전송 처리
+     */
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void processDataPlatformSending(OrderCreatedEvent event) {
+        try {
+            log.info("📊 [OrderEventHandler] 데이터 플랫폼 전송 시작 - OrderId: {}", event.getOrderId());
+
+            DataPlatformResult result = dataPlatformPort.sendOrderData(event);
+
+            if (result.isSuccess()) {
+                log.info("[OrderEventHandler] 데이터 플랫폼 전송 성공 - OrderId: {}, TransactionKey: {}",
+                        event.getOrderId(), result.getTransactionKey());
+            } else {
+                log.error("[OrderEventHandler] 데이터 플랫폼 전송 실패 - OrderId: {}, Error: {}",
+                        event.getOrderId(), result.getMessage());
+
+            }
+
+        } catch (Exception e) {
+            log.error("[OrderEventHandler] 데이터 플랫폼 전송 중 예외 발생 - OrderId: {}, Error: {}",
+                    event.getOrderId(), e.getMessage(), e);
+        }
+    }
+
+    /**
+     * 주문 생성 행동 추적
+     */
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void trackOrderCreationAction(OrderCreatedEvent event) {
+        try {
+            dataPlatformPort.sendUserActionData(
+                    event.getUserId(),
+                    "ORDER_CREATE",
+                    event.getOrderId(),
+                    event.getOccurredAt()
+            );
+
+        } catch (Exception e) {
+            log.error("주문 생성 행동 추적 실패", e);
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderPriceCalculator.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderPriceCalculator.java
@@ -1,0 +1,28 @@
+package com.loopers.application.order;
+
+import com.loopers.application.coupon.CouponProcessor;
+import com.loopers.domain.order.Money;
+import com.loopers.domain.user.UserId;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+
+@Component
+@RequiredArgsConstructor
+public class OrderPriceCalculator {
+
+    private final CouponProcessor couponProcessor;
+
+    public OrderPricing calculate(UserId userId, int originalAmount, String couponCode) {
+        int discountedByCoupon = couponProcessor.applyCouponDiscount(userId, originalAmount, couponCode);
+
+        return OrderPricing.builder()
+                .originalAmount(Money.of(originalAmount))
+                .couponDiscount(Money.of(originalAmount - discountedByCoupon))
+                .finalAmount(Money.of(discountedByCoupon))
+                .couponCode(couponCode)
+                .build();
+    }
+}
+
+

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderPricing.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderPricing.java
@@ -1,0 +1,16 @@
+package com.loopers.application.order;
+
+import com.loopers.domain.order.Money;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.lang.Nullable;
+
+@Getter
+@Builder
+public class OrderPricing {
+    private Money originalAmount;
+    private Money couponDiscount;
+    private Money finalAmount;
+    @Nullable
+    private String couponCode;
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentApplicationService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentApplicationService.java
@@ -133,6 +133,7 @@ public class PaymentApplicationService {
     /**
 	 * 결제 콜백 처리
 	 */
+    @Transactional
 	public void handlePaymentCallback(String transactionKey, PaymentStatus status, String reason) {
 
 		CardPayment cardPayment = cardPaymentRepository.findByTransactionKey(transactionKey)
@@ -143,6 +144,7 @@ public class PaymentApplicationService {
 
 		if (status == PaymentStatus.SUCCESS) {
 			payment.success();
+            paymentRepository.save(payment);
             // 결제 성공 이벤트 발행
             paymentSuccessPublisher.publish(PaymentSuccessEvent.create(
                     payment,
@@ -151,6 +153,7 @@ public class PaymentApplicationService {
 
 		} else {
 			payment.fail();
+            paymentRepository.save(payment);
             // 결제 실패 이벤트 발행
             paymentFailedPublisher.publish(PaymentFailedEvent.create(
                     payment,

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentApplicationService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentApplicationService.java
@@ -1,14 +1,18 @@
 package com.loopers.application.payment;
 
-import com.loopers.application.coupon.CouponProcessor;
 import com.loopers.application.order.OrderInfo;
 import com.loopers.application.point.PointProcessor;
-import com.loopers.application.product.StockDeductionProcessor;
-import com.loopers.domain.order.OrderItemModel;
-import com.loopers.domain.order.OrderItemRepository;
 import com.loopers.domain.order.OrderModel;
 import com.loopers.domain.order.OrderRepository;
 import com.loopers.domain.payment.*;
+import com.loopers.domain.payment.event.PaymentFailedEvent;
+import com.loopers.domain.payment.event.PaymentFailedPublisher;
+import com.loopers.domain.payment.event.PaymentSuccessEvent;
+import com.loopers.domain.payment.event.PaymentSuccessPublisher;
+import com.loopers.domain.payment.model.*;
+import com.loopers.domain.payment.repository.CardPaymentRepository;
+import com.loopers.domain.payment.repository.PaymentRepository;
+import com.loopers.domain.payment.repository.PointPaymentRepository;
 import com.loopers.domain.point.PointModel;
 import com.loopers.domain.point.PointRepository;
 import com.loopers.support.error.InsufficientPointException;
@@ -27,18 +31,16 @@ import java.util.List;
 @RequiredArgsConstructor
 public class PaymentApplicationService {
 
-    private final OrderRepository orderRepository;
-    private final OrderItemRepository orderItemRepository;
+	private final OrderRepository orderRepository;
     private final PaymentRepository paymentRepository;
-    private final PointRepository pointRepository;
-    private final CardPaymentRepository cardPaymentRepository;
-    private final PointPaymentRepository pointPaymentRepository;
+	private final CardPaymentRepository cardPaymentRepository;
+	private final PaymentGatewayPort paymentGatewayPort;
+	private final PaymentSuccessPublisher paymentSuccessPublisher;
+    private final PaymentFailedPublisher paymentFailedPublisher;
 
     private final PointProcessor pointProcessor;
-    private final CouponProcessor couponProcessor;
-    private final StockDeductionProcessor stockDeductionProcessor;
-    private final PaymentGatewayPort paymentGatewayPort;
-    private final PaymentProcessor paymentProcessor;
+    private final PointRepository pointRepository;
+    private final PointPaymentRepository pointPaymentRepository;
 
     /**
      * 카드 결제 요청
@@ -46,29 +48,29 @@ public class PaymentApplicationService {
     public void processCardPayment(OrderInfo orderInfo, PaymentMethod paymentMethod, CardType cardType, String cardNumber) {
         try {
             log.info("카드 결제 요청 시작 - OrderId: {}, Amount: {}", orderInfo.orderId(), orderInfo.totalPrice().getAmount());
-            
+
             PaymentData payment = PaymentData.create(orderInfo.orderId(), paymentMethod, cardType, cardNumber, orderInfo.totalPrice(), orderInfo.userId());
 
             PaymentResult result = paymentGatewayPort.processPayment(payment);
-            
+
             if (result.isSuccess()) {
                 log.info("카드 결제 요청 성공 - OrderId: {}, TransactionKey: {}", orderInfo.orderId(), result.transactionKey());
-                
+
                 PaymentModel paymentInfo = PaymentModel.create(orderInfo.orderId(), paymentMethod, orderInfo.totalPrice());
-                paymentProcessor.save(paymentInfo);
-                
+                paymentRepository.save(paymentInfo);
+
                 CardPayment cardPayment = CardPayment.create(paymentInfo, result.transactionKey(), cardType, cardNumber);
                 cardPaymentRepository.save(cardPayment);
-                
+
                 log.info("카드 결제 정보 저장 완료 - OrderId: {}, PaymentId: {}", orderInfo.orderId(), paymentInfo.getId());
             } else {
-                log.error("카드 결제 요청 실패 - OrderId: {}, TransactionKey: {}, Message: {}", 
-                         orderInfo.orderId(), result.transactionKey(), result.message());
+                log.error("카드 결제 요청 실패 - OrderId: {}, TransactionKey: {}, Message: {}",
+                        orderInfo.orderId(), result.transactionKey(), result.message());
                 throw new PaymentFailedException("카드 결제 요청에 실패했습니다: " + result.message());
             }
         } catch (PaymentFailedException e) {
             log.error("카드 결제 실패 - OrderId: {}, Error: {}", orderInfo.orderId(), e.getMessage());
-            throw e; // PaymentFailedException은 다시 던짐
+            throw e;
         } catch (Exception e) {
             log.error("카드 결제 요청 중 예상치 못한 오류 발생 - OrderId: {}, Error: {}", orderInfo.orderId(), e.getMessage(), e);
             throw new PaymentFailedException("카드 결제 처리 중 오류가 발생했습니다: " + e.getMessage(), e);
@@ -80,18 +82,17 @@ public class PaymentApplicationService {
      */
     @Transactional
     public void processPointPayment(OrderInfo orderInfo, PaymentMethod paymentMethod, int requestPoints) {
+        // 1. Payment 생성
+        PaymentModel payment = PaymentModel.create(orderInfo.orderId(), paymentMethod, orderInfo.totalPrice());
+        PaymentModel savedPayment = paymentRepository.save(payment);
 
         try {
-            // 1. Payment 생성
-            PaymentModel payment = PaymentModel.create(orderInfo.orderId(), paymentMethod, orderInfo.totalPrice());
-            paymentProcessor.save(payment);
-
             // 2. 포인트 사용 처리
             int actualUsedPoints = pointProcessor.processPointUsage(orderInfo.userId(), orderInfo.totalPrice().getAmount(), requestPoints);
 
             // 3. 사용자 잔여 포인트 조회 및 업데이트
             PointModel pointModel = pointRepository.findByUserIdForRead(orderInfo.userId()).orElseThrow(() ->
-                new IllegalArgumentException("사용자의 포인트 정보가 존재하지 않습니다: " + orderInfo.userId()));
+                    new IllegalArgumentException("사용자의 포인트 정보가 존재하지 않습니다: " + orderInfo.userId()));
 
             // 4. PointPayment 상세 정보 생성
             PointPayment pointPayment = PointPayment.create(payment, pointModel, actualUsedPoints);
@@ -102,10 +103,8 @@ public class PaymentApplicationService {
             // 5. 결제 성공 처리
             payment.success();
 
-            // 6. 주문 상태 확정
-            OrderModel order = orderRepository.findById(orderInfo.orderId())
-                    .orElseThrow(() -> new IllegalArgumentException("주문이 존재하지 않습니다: " + orderInfo.orderId()));
-            order.confirm();
+            // 6. 결제 성공 이벤트 발행
+            paymentSuccessPublisher.publish(PaymentSuccessEvent.create(payment,"POINT-IMMEDIATE"));
 
             log.info("포인트 결제 완료: orderId={}, usedPoints={}, remainingPoints={}",
                     orderInfo.orderId(), actualUsedPoints, pointModel.getAmount());
@@ -114,127 +113,112 @@ public class PaymentApplicationService {
             log.error("포인트 부족: orderId={}, requestPoints={}, error={}",
                     orderInfo.orderId(), requestPoints, e.getMessage());
 
+            // 결제 실패 이벤트 발행
+            paymentFailedPublisher.publish(PaymentFailedEvent.create(savedPayment,"포인트 부족"));
+
             throw new PaymentFailedException("포인트가 부족합니다: " + e.getMessage());
 
         } catch (Exception e) {
             log.error("포인트 결제 중 오류 발생: orderId={}, error={}", orderInfo.orderId(), e.getMessage(), e);
 
+            // 결제 실패 이벤트 발행
+            paymentFailedPublisher.publish(PaymentFailedEvent.create(
+                    savedPayment,
+                    "포인트 결제 도중 알 수 없는 오류 발생"
+            ));
             throw new PaymentFailedException("포인트 결제에 실패했습니다: " + e.getMessage());
         }
     }
-    
 
     /**
-     * 결제 콜백 처리
-     */
-    @Transactional
-    public void handlePaymentCallback(String transactionKey, PaymentStatus status, String reason) {
+	 * 결제 콜백 처리
+	 */
+	public void handlePaymentCallback(String transactionKey, PaymentStatus status, String reason) {
 
-        CardPayment cardPayment = cardPaymentRepository.findByTransactionKey(transactionKey)
-                .orElseThrow(() -> new IllegalArgumentException("결제 내역이 존재하지 않습니다: " + transactionKey));
+		CardPayment cardPayment = cardPaymentRepository.findByTransactionKey(transactionKey)
+				.orElseThrow(() -> new IllegalArgumentException("결제 내역이 존재하지 않습니다: " + transactionKey));
 
-        PaymentModel payment = paymentRepository.findById(cardPayment.getPaymentId()).orElseThrow(()
-                -> new IllegalArgumentException("결제 정보가 존재하지 않습니다: paymentId=" + cardPayment.getPaymentId()));
+		PaymentModel payment = paymentRepository.findById(cardPayment.getPaymentId()).orElseThrow(()
+				-> new IllegalArgumentException("결제 정보가 존재하지 않습니다: paymentId=" + cardPayment.getPaymentId()));
 
-        OrderModel order = orderRepository.findById(payment.getOrderId())
-                .orElseThrow(() -> new IllegalArgumentException("주문 내역이 존재하지 않습니다: " + payment.getOrderId()));
+		if (status == PaymentStatus.SUCCESS) {
+			payment.success();
+            // 결제 성공 이벤트 발행
+            paymentSuccessPublisher.publish(PaymentSuccessEvent.create(
+                    payment,
+					transactionKey
+			));
 
-        List<OrderItemModel> orderItems = orderItemRepository.findByOrderId(order.getId());
+		} else {
+			payment.fail();
+            // 결제 실패 이벤트 발행
+            paymentFailedPublisher.publish(PaymentFailedEvent.create(
+                    payment,
+					reason
+			));
 
-        if (status == PaymentStatus.SUCCESS) {
-            order.confirm();
-            payment.success();
+		}
 
-            // 쿠폰 사용 처리
-            couponProcessor.useCoupon(order.getUserId(), order.getCouponCode());
+	}
 
-        } else {
-            order.cancel();
-            payment.fail();
-            // 재고 복구
-            stockDeductionProcessor.restoreProductStocks(orderItems);
-            // 쿠폰 복구
-            couponProcessor.restoreCoupon(order.getUserId(), order.getCouponCode());
+	/**
+	 * 결제 콜백 검증
+	 */
+	public void validatePaymentCallback(String transactionKey) {
 
-        }
+		CardPayment cardPayment = cardPaymentRepository.findByTransactionKey(transactionKey).orElseThrow(
+				() -> new IllegalArgumentException("결제 내역이 존재하지 않습니다: " + transactionKey)
+		);
+		PaymentModel paymentModel = paymentRepository.findById(cardPayment.getPaymentId()).orElseThrow(
+				() -> new IllegalArgumentException("결제 정보가 존재하지 않습니다: paymentId=" + cardPayment.getPaymentId()
+		));
+		OrderModel orderModel = orderRepository.findById(paymentModel.getOrderId()).orElseThrow(
+				() -> new IllegalArgumentException("주문 내역이 존재하지 않습니다: " + paymentModel.getOrderId()
+		));
 
-    }
+		PaymentQueryResult queryResult = paymentGatewayPort.queryPaymentStatus(orderModel.getUserId().getValue(), transactionKey);
+		if (!queryResult.isQuerySuccess()) {
+			throw new IllegalArgumentException("결제 상태 조회 실패: " + queryResult.reason());
+		}
+		if (queryResult.status() != PaymentStatus.PENDING) {
+			throw new IllegalArgumentException("이미 처리된 결제입니다: " + transactionKey);
+		}
 
-    /**
-     * 결제 콜백 검증
-     */
-    public void validatePaymentCallback(String transactionKey) {
+	}
 
-        CardPayment cardPayment = cardPaymentRepository.findByTransactionKey(transactionKey).orElseThrow(
-                () -> new IllegalArgumentException("결제 내역이 존재하지 않습니다: " + transactionKey)
-        );
-        PaymentModel paymentModel = paymentRepository.findById(cardPayment.getPaymentId()).orElseThrow(
-                () -> new IllegalArgumentException("결제 정보가 존재하지 않습니다: paymentId=" + cardPayment.getPaymentId()
-        ));
-        OrderModel orderModel = orderRepository.findById(paymentModel.getOrderId()).orElseThrow(
-                () -> new IllegalArgumentException("주문 내역이 존재하지 않습니다: " + paymentModel.getOrderId()
-        ));
+	@Scheduled(fixedDelay = 600000) // 10분마다 결제 상태 점검
+	@Transactional
+	public void checkPendingPayments() {
 
-        PaymentQueryResult queryResult = paymentGatewayPort.queryPaymentStatus(orderModel.getUserId().getValue(), transactionKey);
-        if (!queryResult.isQuerySuccess()) {
-            throw new IllegalArgumentException("결제 상태 조회 실패: " + queryResult.reason());
-        }
-        if (queryResult.status() != PaymentStatus.PENDING) {
-            throw new IllegalArgumentException("이미 처리된 결제입니다: " + transactionKey);
-        }
+		List<PaymentModel> pendingPayments = paymentRepository.findByStatusAndCreatedBefore(
+				PaymentStatus.PENDING,
+				ZonedDateTime.now().minusMinutes(5)
+		);
 
-    }
+		for (PaymentModel payment : pendingPayments) {
+			CardPayment cardPay = cardPaymentRepository.findByPaymentId(payment.getId())
+					.orElseThrow(() -> new IllegalStateException("결제 정보가 존재하지 않습니다: paymentId=" + payment.getId()));
+			OrderModel orderModel = orderRepository.findById(payment.getOrderId()).orElseThrow(
+					() -> new IllegalStateException("주문 정보가 존재하지 않습니다: orderId=" + payment.getOrderId()
+					));
+			try {
+				PaymentQueryResult queryResult = paymentGatewayPort.queryPaymentStatus(orderModel.getUserId().getValue(), cardPay.getTransactionKey());
 
-    @Scheduled(fixedDelay = 600000) // 10분마다 결제 상태 점검
-    @Transactional
-    public void checkPendingPayments() {
+				if (queryResult.isQuerySuccess() && queryResult.status() != PaymentStatus.PENDING) {
 
-        List<PaymentModel> pendingPayments = paymentRepository.findByStatusAndCreatedBefore(
-                PaymentStatus.PENDING,
-                ZonedDateTime.now().minusMinutes(5)
-        );
+					handlePaymentCallback(
+							cardPay.getTransactionKey(),
+							queryResult.status(),
+							queryResult.reason() + " (스케줄러 확인)"
+					);
+					log.info("PENDING 결제 상태 업데이트: paymentId={}, orderId={}, status={}",
+							payment.getId(), payment.getOrderId(), queryResult.status());
+				}
+			} catch (Exception e) {
+				log.error("결제 상태 확인 실패: paymentId={}, orderId={}, transactionKey={}, error={}",
+						payment.getId(), payment.getOrderId(), cardPay.getTransactionKey(), e.getMessage());
+			}
+		}
+	}
 
-        for (PaymentModel payment : pendingPayments) {
-            CardPayment cardPay = cardPaymentRepository.findByPaymentId(payment.getId())
-                    .orElseThrow(() -> new IllegalStateException("결제 정보가 존재하지 않습니다: paymentId=" + payment.getId()));
-            OrderModel orderModel = orderRepository.findById(payment.getOrderId()).orElseThrow(
-                    () -> new IllegalStateException("주문 정보가 존재하지 않습니다: orderId=" + payment.getOrderId()
-                    ));
-            try {
-                PaymentQueryResult queryResult = paymentGatewayPort.queryPaymentStatus(orderModel.getUserId().getValue(), cardPay.getTransactionKey());
-
-                if (queryResult.isQuerySuccess() && queryResult.status() != PaymentStatus.PENDING) {
-
-                    handlePaymentCallback(
-                            cardPay.getTransactionKey(),
-                            queryResult.status(),
-                            queryResult.reason() + " (스케줄러 확인)"
-                    );
-                    log.info("PENDING 결제 상태 업데이트: paymentId={}, orderId={}, status={}",
-                            payment.getId(), payment.getOrderId(), queryResult.status());
-                }
-            } catch (Exception e) {
-                log.error("결제 상태 확인 실패: paymentId={}, orderId={}, transactionKey={}, error={}",
-                        payment.getId(), payment.getOrderId(), cardPay.getTransactionKey(), e.getMessage());
-            }
-        }
-    }
-
-    public void handlePaymentFailure(Long orderId) {
-        try {
-            OrderModel order = orderRepository.findById(orderId)
-                    .orElseThrow(() -> new IllegalArgumentException("주문이 존재하지 않습니다: " + orderId));
-            order.cancel(); // 또는 FAILED 상태로 변경
-            orderRepository.save(order);
-            // 재고 복구
-            List<OrderItemModel> orderItems = orderItemRepository.findByOrderId(order.getId());
-            stockDeductionProcessor.restoreProductStocks(orderItems);
-            // 쿠폰 복구
-            couponProcessor.restoreCoupon(order.getUserId(), order.getCouponCode());
-
-            log.info("결제 실패로 인한 주문 취소 완료 - OrderId: {}", orderId);
-        } catch (Exception e) {
-            log.error("결제 실패 처리 중 오류 발생 - OrderId: {}, Error: {}", orderId, e.getMessage(), e);
-        }
-    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentFailureEventHandler.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentFailureEventHandler.java
@@ -1,0 +1,92 @@
+package com.loopers.application.payment;
+
+import com.loopers.application.coupon.CouponProcessor;
+import com.loopers.application.product.StockDeductionProcessor;
+import com.loopers.domain.coupon.UserCouponModel;
+import com.loopers.domain.order.OrderItemModel;
+import com.loopers.domain.order.OrderItemRepository;
+import com.loopers.domain.order.OrderModel;
+import com.loopers.domain.order.OrderRepository;
+import com.loopers.domain.payment.event.PaymentFailedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PaymentFailureEventHandler {
+
+    private final OrderRepository orderRepository;
+    private final OrderItemRepository orderItemRepository;
+    private final StockDeductionProcessor stockDeductionProcessor;
+    private final CouponProcessor couponProcessor;
+
+    /**
+     * 결제 실패 - 주문 취소 이벤트 처리
+     */
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handlePaymentFailed(PaymentFailedEvent event) {
+
+        try {
+            // 주문 조회
+            OrderModel order = orderRepository.findById(event.getOrderId())
+                    .orElseThrow(() -> new IllegalArgumentException("주문을 찾을 수 없습니다: " + event.getOrderId()));
+
+            // 주문 상태를 CANCELLED로 변경
+            order.cancel();
+            orderRepository.save(order);
+            log.info("[PaymentEventHandler] 주문 상태 취소 완료 - OrderId: {}", event.getOrderId());
+
+        } catch (Exception e) {
+            log.error("[PaymentEventHandler] 주문 취소 이벤트 처리 중 예외 발생 - OrderId: {}, Error: {}",
+                    event.getOrderId(), e.getMessage(), e);
+        }
+    }
+
+    /**
+     * 결제 실패 - 재고 복구 이벤트 처리
+     */
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    public void handlePaymentFailedWithStockRestoration(PaymentFailedEvent event) {
+
+        try {
+            // 주문 아이템 조회
+            List<OrderItemModel> orderItems = orderItemRepository.findByOrderId(event.getOrderId());
+
+            // 재고 복구
+            stockDeductionProcessor.restoreProductStocks(orderItems);
+            log.info("[PaymentEventHandler] 재고 복구 완료 - OrderId: {}", event.getOrderId());
+
+        } catch (Exception e) {
+            log.error("[PaymentEventHandler] 재고 복구 이벤트 처리 중 예외 발생 - OrderId: {}, Error: {}",
+                    event.getOrderId(), e.getMessage(), e);
+        }
+    }
+
+    /**
+     * 결제 실패 - 쿠폰 복구 이벤트 처리
+     */
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    public void handlePaymentFailedWithCouponRestoration(PaymentFailedEvent event) {
+
+        try {
+            OrderModel order = orderRepository.findById(event.getOrderId())
+                    .orElseThrow(() -> new IllegalArgumentException("주문을 찾을 수 없습니다: " + event.getOrderId()));
+
+            UserCouponModel coupon = couponProcessor.findByOrderId(event.getOrderId());
+            couponProcessor.restoreCoupon(order.getUserId(), coupon.getCouponCode());
+            log.info("[PaymentEventHandler] 쿠폰 복구 완료 - OrderId: {}", event.getOrderId());
+
+        } catch (Exception e) {
+            log.error("[PaymentEventHandler] 쿠폰 복구 이벤트 처리 중 예외 발생 - OrderId: {}, Error: {}",
+                    event.getOrderId(), e.getMessage(), e);
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentFailureEventHandler.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentFailureEventHandler.java
@@ -3,11 +3,16 @@ package com.loopers.application.payment;
 import com.loopers.application.coupon.CouponProcessor;
 import com.loopers.application.product.StockDeductionProcessor;
 import com.loopers.domain.coupon.UserCouponModel;
+import com.loopers.domain.external.DataPlatformPort;
+import com.loopers.domain.external.DataPlatformResult;
 import com.loopers.domain.order.OrderItemModel;
 import com.loopers.domain.order.OrderItemRepository;
 import com.loopers.domain.order.OrderModel;
 import com.loopers.domain.order.OrderRepository;
 import com.loopers.domain.payment.event.PaymentFailedEvent;
+import com.loopers.domain.user.event.UserActionData;
+import com.loopers.domain.user.event.UserActionTrackingPort;
+import com.loopers.domain.user.event.UserActionType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
@@ -26,6 +31,8 @@ public class PaymentFailureEventHandler {
     private final OrderItemRepository orderItemRepository;
     private final StockDeductionProcessor stockDeductionProcessor;
     private final CouponProcessor couponProcessor;
+    private final DataPlatformPort dataPlatformPort;
+    private final UserActionTrackingPort userActionTrackingPort;
 
     /**
      * 결제 실패 - 주문 취소 이벤트 처리
@@ -87,6 +94,54 @@ public class PaymentFailureEventHandler {
         } catch (Exception e) {
             log.error("[PaymentEventHandler] 쿠폰 복구 이벤트 처리 중 예외 발생 - OrderId: {}, Error: {}",
                     event.getOrderId(), e.getMessage(), e);
+        }
+    }
+
+    /**
+     * 데이터 플랫폼 전송 처리
+     */
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void processDataPlatformSending(PaymentFailedEvent event) {
+        try {
+            log.info("📊 [OrderEventHandler] 데이터 플랫폼 전송 시작 - OrderId: {}", event.getOrderId());
+
+            DataPlatformResult result = dataPlatformPort.sendPaymentFailure(event);
+
+            if (result.isSuccess()) {
+                log.info("[OrderEventHandler] 데이터 플랫폼 전송 성공 - OrderId: {}",
+                        event.getOrderId());
+            } else {
+                log.error("[OrderEventHandler] 데이터 플랫폼 전송 실패 - OrderId: {}, Error: {}",
+                        event.getOrderId(), result.getMessage());
+
+            }
+
+        } catch (Exception e) {
+            log.error("[OrderEventHandler] 데이터 플랫폼 전송 중 예외 발생 - OrderId: {}, Error: {}",
+                    event.getOrderId(), e.getMessage(), e);
+        }
+    }
+
+    /**
+     * 결제 성공 행동 추적
+     */
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void trackOrderCreationAction(PaymentFailedEvent event) {
+        try {
+            OrderModel order = orderRepository.findById(event.getOrderId()).orElseThrow(
+                    () -> new IllegalArgumentException("주문을 찾을 수 없습니다: " + event.getOrderId())
+            );
+            UserActionData actionData = UserActionData.create(
+                    order.getUserId(),
+                    UserActionType.PAYMENT_FAILURE,
+                    event.getOrderId()
+            );
+            userActionTrackingPort.trackUserAction(actionData);
+
+        } catch (Exception e) {
+            log.error("결제 성공 행동 추적 실패", e);
         }
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentProcessor.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentProcessor.java
@@ -1,7 +1,7 @@
 package com.loopers.application.payment;
 
-import com.loopers.domain.payment.PaymentModel;
-import com.loopers.domain.payment.PaymentRepository;
+import com.loopers.domain.payment.model.PaymentModel;
+import com.loopers.domain.payment.repository.PaymentRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentSuccessEventHandler.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentSuccessEventHandler.java
@@ -2,9 +2,14 @@ package com.loopers.application.payment;
 
 import com.loopers.application.coupon.CouponProcessor;
 import com.loopers.domain.coupon.UserCouponModel;
+import com.loopers.domain.external.DataPlatformPort;
+import com.loopers.domain.external.DataPlatformResult;
 import com.loopers.domain.order.OrderModel;
 import com.loopers.domain.order.OrderRepository;
 import com.loopers.domain.payment.event.PaymentSuccessEvent;
+import com.loopers.domain.user.event.UserActionData;
+import com.loopers.domain.user.event.UserActionTrackingPort;
+import com.loopers.domain.user.event.UserActionType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
@@ -19,6 +24,8 @@ public class PaymentSuccessEventHandler {
 
 	private final OrderRepository orderRepository;
 	private final CouponProcessor couponProcessor;
+    private final DataPlatformPort dataPlatformPort;
+    private final UserActionTrackingPort userActionTrackingPort;
 
 	/**
 	 * 결제 성공 - 주문 확정 이벤트 처리
@@ -64,5 +71,53 @@ public class PaymentSuccessEventHandler {
 					event.getOrderId(), e.getMessage(), e);
 		}
 	}
+
+    /**
+     * 데이터 플랫폼 전송 처리
+     */
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void processDataPlatformSending(PaymentSuccessEvent event) {
+        try {
+            log.info("📊 [OrderEventHandler] 데이터 플랫폼 전송 시작 - OrderId: {}", event.getOrderId());
+
+            DataPlatformResult result = dataPlatformPort.sendPaymentSuccess(event);
+
+            if (result.isSuccess()) {
+                log.info("[OrderEventHandler] 데이터 플랫폼 전송 성공 - OrderId: {}, TransactionKey: {}",
+                        event.getOrderId(), result.getTransactionKey());
+            } else {
+                log.error("[OrderEventHandler] 데이터 플랫폼 전송 실패 - OrderId: {}, Error: {}",
+                        event.getOrderId(), result.getMessage());
+
+            }
+
+        } catch (Exception e) {
+            log.error("[OrderEventHandler] 데이터 플랫폼 전송 중 예외 발생 - OrderId: {}, Error: {}",
+                    event.getOrderId(), e.getMessage(), e);
+        }
+    }
+
+    /**
+     * 결제 성공 행동 추적
+     */
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void trackOrderCreationAction(PaymentSuccessEvent event) {
+        try {
+            OrderModel order = orderRepository.findById(event.getOrderId()).orElseThrow(
+                    () -> new IllegalArgumentException("주문을 찾을 수 없습니다: " + event.getOrderId())
+            );
+            UserActionData actionData = UserActionData.create(
+                    order.getUserId(),
+                    UserActionType.PAYMENT_SUCCESS,
+                    event.getPaymentId()
+            );
+            userActionTrackingPort.trackUserAction(actionData);
+
+        } catch (Exception e) {
+            log.error("결제 성공 행동 추적 실패", e);
+        }
+    }
 
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentSuccessEventHandler.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentSuccessEventHandler.java
@@ -1,0 +1,68 @@
+package com.loopers.application.payment;
+
+import com.loopers.application.coupon.CouponProcessor;
+import com.loopers.domain.coupon.UserCouponModel;
+import com.loopers.domain.order.OrderModel;
+import com.loopers.domain.order.OrderRepository;
+import com.loopers.domain.payment.event.PaymentSuccessEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PaymentSuccessEventHandler {
+
+	private final OrderRepository orderRepository;
+	private final CouponProcessor couponProcessor;
+
+	/**
+	 * 결제 성공 - 주문 확정 이벤트 처리
+	 */
+    @Async
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	public void handlePaymentSuccess(PaymentSuccessEvent event) {
+		log.info("[PaymentEventHandler] 결제 성공 이벤트 처리 시작 - OrderId: {}, PaymentId: {}",
+				event.getOrderId(), event.getPaymentId());
+
+		try {
+			// 주문 상태를 CONFIRMED로 변경
+			OrderModel order = orderRepository.findById(event.getOrderId())
+					.orElseThrow(() -> new IllegalArgumentException("주문을 찾을 수 없습니다: " + event.getOrderId()));
+
+			order.confirm();
+			orderRepository.save(order);
+
+			log.info("[PaymentEventHandler] 주문 확정 완료 - OrderId: {}", event.getOrderId());
+
+		} catch (Exception e) {
+			log.error("[PaymentEventHandler] 결제 성공 이벤트 처리 중 예외 발생 - OrderId: {}, Error: {}",
+					event.getOrderId(), e.getMessage(), e);
+		}
+	}
+
+	/**
+	 * 결제 성공 - 쿠폰 사용 확정 이벤트 처리
+	 */
+	@TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+	public void handlePaymentSuccessWithCouponConfirmation(PaymentSuccessEvent event) {
+		log.info("[PaymentEventHandler] 결제 성공 - 쿠폰 사용 확정 이벤트 처리 시작 - OrderId: {}, PaymentId: {}",
+				event.getOrderId(), event.getPaymentId());
+		try {
+            OrderModel order = orderRepository.findById(event.getOrderId())
+                    .orElseThrow(() -> new IllegalArgumentException("주문을 찾을 수 없습니다: " + event.getOrderId()));
+            UserCouponModel myCoupon = couponProcessor.findByOrderId(event.getOrderId());
+            couponProcessor.useCoupon(order.getUserId(), myCoupon.getCouponCode(), myCoupon.getOrderId());
+			log.info("[PaymentEventHandler] 쿠폰 사용 확정 완료 - OrderId: {}", event.getOrderId());
+
+		} catch (Exception e) {
+			log.error("[PaymentEventHandler] 쿠폰 사용 확정 이벤트 처리 중 예외 발생 - OrderId: {}, Error: {}",
+					event.getOrderId(), e.getMessage(), e);
+		}
+	}
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductApplicationService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductApplicationService.java
@@ -8,6 +8,9 @@ import com.loopers.domain.product.ProductModel;
 import com.loopers.domain.product.ProductRepository;
 import com.loopers.domain.product.ProductSearchDomainService;
 import com.loopers.domain.product.ProductSortBy;
+import com.loopers.domain.product.event.ProductChangedPublisher;
+import com.loopers.domain.product.event.ProductViewedEvent;
+import com.loopers.domain.user.UserId;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -25,6 +28,8 @@ public class ProductApplicationService {
     private final CategoryRepository categoryRepository;
     private final ProductSearchDomainService productSearchDomainService;
     private final ProductCacheService productCacheService;
+
+    private final ProductChangedPublisher eventPublisher;
 
     /**
      * 상품 목록 조회 (페이징 / 정렬 - 최신순(기본값), 좋아요순, 가격 낮은 순, 가격 높은 순)
@@ -137,7 +142,7 @@ public class ProductApplicationService {
     /**
      * 상품 상세 조회
      */
-    public ProductOutputInfo getProductDetail(Long id) {
+    public ProductOutputInfo getProductDetail(Long id, String userId) {
 
         ProductModel productModel = productRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("해당 상품을 찾을 수 없습니다."));
@@ -155,6 +160,15 @@ public class ProductApplicationService {
 
         ProductOutputInfo result = ProductOutputInfo.convertToInfo(productModel, brandModel, categoryModel);
 
+        if (userId != null && !userId.isBlank()) {
+            try {
+                eventPublisher.publishEvent(
+                        ProductViewedEvent.createDetailView(id, UserId.of(userId))
+                );
+            } catch (Exception e) {
+                log.warn("상품 조회 이벤트 발행 실패 - ProductId: {}, UserId: {}", id, userId, e);
+            }
+        }
         return result;
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductApplicationService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductApplicationService.java
@@ -8,7 +8,7 @@ import com.loopers.domain.product.ProductModel;
 import com.loopers.domain.product.ProductRepository;
 import com.loopers.domain.product.ProductSearchDomainService;
 import com.loopers.domain.product.ProductSortBy;
-import com.loopers.domain.product.event.ProductChangedPublisher;
+import com.loopers.domain.product.event.ProductDetailViewedPublisher;
 import com.loopers.domain.product.event.ProductViewedEvent;
 import com.loopers.domain.user.UserId;
 import lombok.RequiredArgsConstructor;
@@ -29,7 +29,7 @@ public class ProductApplicationService {
     private final ProductSearchDomainService productSearchDomainService;
     private final ProductCacheService productCacheService;
 
-    private final ProductChangedPublisher eventPublisher;
+    private final ProductDetailViewedPublisher detailViewedPublisher;
 
     /**
      * 상품 목록 조회 (페이징 / 정렬 - 최신순(기본값), 좋아요순, 가격 낮은 순, 가격 높은 순)
@@ -162,7 +162,8 @@ public class ProductApplicationService {
 
         if (userId != null && !userId.isBlank()) {
             try {
-                eventPublisher.publishEvent(
+                // 상품 조회 이벤트 발행
+                detailViewedPublisher.publish(
                         ProductViewedEvent.createDetailView(id, UserId.of(userId))
                 );
             } catch (Exception e) {

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductCacheEventListener.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductCacheEventListener.java
@@ -1,5 +1,6 @@
 package com.loopers.application.product;
 
+import com.loopers.domain.product.event.ProductChangedEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
@@ -37,31 +38,4 @@ public class ProductCacheEventListener {
         }
     }
 
-    /**
-     * 상품 변경 이벤트
-     */
-    public static class ProductChangedEvent {
-        private final Long productId;
-        private final ChangeType changeType;
-
-        public ProductChangedEvent(Long productId, ChangeType changeType) {
-            this.productId = productId;
-            this.changeType = changeType;
-        }
-
-        public Long getProductId() {
-            return productId;
-        }
-
-        public ChangeType getChangeType() {
-            return changeType;
-        }
-    }
-
-    /**
-     * 변경 타입
-     */
-    public enum ChangeType {
-        CREATED, UPDATED, DELETED
-    }
 } 

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/UserActingTrackingForProductEventHandler.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/UserActingTrackingForProductEventHandler.java
@@ -1,0 +1,102 @@
+package com.loopers.application.product;
+
+
+import com.loopers.domain.product.event.ProductClickedEvent;
+import com.loopers.domain.product.event.ProductViewedEvent;
+import com.loopers.domain.user.event.UserActionData;
+import com.loopers.domain.user.event.UserActionTrackingPort;
+import com.loopers.domain.user.event.UserActionType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class UserActingTrackingForProductEventHandler {
+
+    private final UserActionTrackingPort userActionTrackingPort;
+
+    /**
+     * 상품 조회 이벤트 처리
+     */
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Async
+    public void handleProductViewed(ProductViewedEvent event) {
+        log.info("[ProductEventHandler] 상품 조회 이벤트 처리 - ProductId: {}, UserId: {}, ViewType: {}",
+                event.getProductId(), event.getUserId().getValue(), event.getViewType());
+
+        try {
+            // 사용자 행동 추적
+            String additionalInfo = buildViewAdditionalInfo(event);
+            UserActionData actionData = UserActionData.create(
+                    event.getUserId(),
+                    UserActionType.PRODUCT_VIEW,
+                    event.getProductId(),
+                    additionalInfo
+            );
+
+            userActionTrackingPort.trackUserAction(actionData);
+
+        } catch (Exception e) {
+            log.error("[ProductEventHandler] 상품 조회 이벤트 처리 실패 - ProductId: {}, Error: {}",
+                    event.getProductId(), e.getMessage(), e);
+        }
+    }
+
+    /**
+     * 상품 클릭 이벤트 처리
+     */
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Async
+    public void handleProductClicked(ProductClickedEvent event) {
+        log.info("[ProductEventHandler] 상품 클릭 이벤트 처리 - ProductId: {}, UserId: {}, Context: {}",
+                event.getProductId(), event.getUserId().getValue(), event.getClickContext());
+
+        try {
+            // 사용자 클릭 행동 추적
+            String additionalInfo = buildClickAdditionalInfo(event);
+            UserActionData actionData = UserActionData.create(
+                    event.getUserId(),
+                    UserActionType.PRODUCT_CLICK,
+                    event.getProductId(),
+                    additionalInfo
+            );
+            userActionTrackingPort.trackUserAction(actionData);
+
+        } catch (Exception e) {
+            log.error("[ProductEventHandler] 상품 클릭 이벤트 처리 실패 - ProductId: {}, Error: {}",
+                    event.getProductId(), e.getMessage(), e);
+        }
+    }
+
+    /**
+     * 상품 조회 이벤트의 추가 정보 생성
+     */
+    private String buildViewAdditionalInfo(ProductViewedEvent event) {
+        StringBuilder info = new StringBuilder();
+        info.append("view_type=").append(event.getViewType());
+
+        if (event.getReferrer() != null) {
+            info.append(",referrer=").append(event.getReferrer());
+        }
+
+        return info.toString();
+    }
+
+    /**
+     * 상품 클릭 이벤트의 추가 정보 생성
+     */
+    private String buildClickAdditionalInfo(ProductClickedEvent event) {
+        StringBuilder info = new StringBuilder();
+        info.append("click_context=").append(event.getClickContext());
+        if (event.getPosition() != null) {
+            info.append(",position=").append(event.getPosition());
+        }
+        return info.toString();
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/UserActingTrackingForProductEventHandler.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/UserActingTrackingForProductEventHandler.java
@@ -8,10 +8,9 @@ import com.loopers.domain.user.event.UserActionTrackingPort;
 import com.loopers.domain.user.event.UserActionType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.event.TransactionPhase;
-import org.springframework.transaction.event.TransactionalEventListener;
 
 @Slf4j
 @Component
@@ -23,7 +22,7 @@ public class UserActingTrackingForProductEventHandler {
     /**
      * 상품 조회 이벤트 처리
      */
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @EventListener
     @Async
     public void handleProductViewed(ProductViewedEvent event) {
         log.info("[ProductEventHandler] 상품 조회 이벤트 처리 - ProductId: {}, UserId: {}, ViewType: {}",
@@ -50,7 +49,7 @@ public class UserActingTrackingForProductEventHandler {
     /**
      * 상품 클릭 이벤트 처리
      */
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @EventListener
     @Async
     public void handleProductClicked(ProductClickedEvent event) {
         log.info("[ProductEventHandler] 상품 클릭 이벤트 처리 - ProductId: {}, UserId: {}, Context: {}",

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/UserCouponModel.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/UserCouponModel.java
@@ -23,6 +23,8 @@ public class UserCouponModel extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private UserCoupontStatus status = UserCoupontStatus.AVAILABLE;
 
+    private Long orderId = 0L;
+
     private LocalDate issuedAt;
 
     private LocalDate usedAt;
@@ -34,12 +36,12 @@ public class UserCouponModel extends BaseEntity {
         }
         userCouponModel.userId = userId;
         userCouponModel.couponCode = couponCode;
-        userCouponModel.status = UserCoupontStatus.AVAILABLE;;
+        userCouponModel.status = UserCoupontStatus.AVAILABLE;
         userCouponModel.issuedAt = LocalDate.now();
         return userCouponModel;
     }
 
-    public boolean useCoupon(LocalDate usedAt) {
+    public boolean useCoupon(LocalDate usedAt, Long orderId) {
         if (this.status == UserCoupontStatus.USED) {
             throw new IllegalArgumentException("이미 사용된 쿠폰입니다.");
         }
@@ -48,6 +50,9 @@ public class UserCouponModel extends BaseEntity {
         }
         if (usedAt.isBefore(issuedAt)) {
             throw new IllegalArgumentException("쿠폰이 아직 발급되지 않았습니다.");
+        }
+        if (!orderId.equals(this.orderId)) {
+            throw new IllegalArgumentException("주문 정보가 맞지 않습니다.");
         }
         this.markAsUsed(usedAt);
         return true;
@@ -64,19 +69,13 @@ public class UserCouponModel extends BaseEntity {
         this.usedAt = usedAt;
     }
 
-    public void reserve() {
+    public void reserve(Long orderId) {
         if (this.status != UserCoupontStatus.AVAILABLE) {
             throw new IllegalStateException("사용할 수 없는 쿠폰입니다.");
         }
         this.status = UserCoupontStatus.RESERVED;
-    }
+        this.orderId = orderId;
 
-    public void completeUsage() {
-        if (this.status != UserCoupontStatus.RESERVED) {
-            throw new IllegalStateException("사용 완료 처리할 수 없는 쿠폰입니다.");
-        }
-        this.status = UserCoupontStatus.USED;
-        this.usedAt = LocalDate.now();
     }
 
     public void cancelReservation() {
@@ -84,6 +83,7 @@ public class UserCouponModel extends BaseEntity {
             throw new IllegalStateException("예약 취소할 수 없는 쿠폰입니다.");
         }
         this.status = UserCoupontStatus.AVAILABLE;
+        this.orderId = 0L;
     }
 
 

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/UserCouponModel.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/UserCouponModel.java
@@ -23,7 +23,7 @@ public class UserCouponModel extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private UserCoupontStatus status = UserCoupontStatus.AVAILABLE;
 
-    private Long orderId = 0L;
+    private Long orderId;
 
     private LocalDate issuedAt;
 
@@ -83,7 +83,7 @@ public class UserCouponModel extends BaseEntity {
             throw new IllegalStateException("예약 취소할 수 없는 쿠폰입니다.");
         }
         this.status = UserCoupontStatus.AVAILABLE;
-        this.orderId = 0L;
+        this.orderId = null;
     }
 
 

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/UserCouponRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/UserCouponRepository.java
@@ -8,4 +8,6 @@ public interface UserCouponRepository {
     Optional<UserCouponModel> findByUserIdAndCouponCode(UserId userId, String couponCode);
 
     UserCouponModel save(UserCouponModel userCoupon);
+
+    Optional<UserCouponModel> findByOrderId(Long orderId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/external/DataPlatformPort.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/external/DataPlatformPort.java
@@ -1,13 +1,12 @@
 package com.loopers.domain.external;
 
 import com.loopers.domain.order.event.OrderCreatedEvent;
-import com.loopers.domain.user.UserId;
-
-import java.time.ZonedDateTime;
+import com.loopers.domain.payment.event.PaymentFailedEvent;
+import com.loopers.domain.payment.event.PaymentSuccessEvent;
 
 public interface DataPlatformPort {
 
     DataPlatformResult sendOrderData(OrderCreatedEvent event);
-    void sendUserActionData(UserId userId, String action, Long targetId, ZonedDateTime timestamp);
-
+    DataPlatformResult sendPaymentSuccess(PaymentSuccessEvent event);
+    DataPlatformResult sendPaymentFailure(PaymentFailedEvent event);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/external/DataPlatformPort.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/external/DataPlatformPort.java
@@ -1,0 +1,13 @@
+package com.loopers.domain.external;
+
+import com.loopers.domain.order.event.OrderCreatedEvent;
+import com.loopers.domain.user.UserId;
+
+import java.time.ZonedDateTime;
+
+public interface DataPlatformPort {
+
+    DataPlatformResult sendOrderData(OrderCreatedEvent event);
+    void sendUserActionData(UserId userId, String action, Long targetId, ZonedDateTime timestamp);
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/external/DataPlatformResult.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/external/DataPlatformResult.java
@@ -1,0 +1,22 @@
+package com.loopers.domain.external;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class DataPlatformResult {
+
+    private final boolean success;
+    private final String message;
+    private final String transactionKey;
+
+    public static DataPlatformResult success(String transactionId) {
+        return new DataPlatformResult(true, "데이터 전송 성공", transactionId);
+    }
+
+    public static DataPlatformResult failed(String message) {
+        return new DataPlatformResult(false, message, null);
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/ProductLikeDomainService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/ProductLikeDomainService.java
@@ -22,14 +22,7 @@ public class ProductLikeDomainService {
         if (isLiked(product.getId(), userId)) {
             return null; // 이미 좋아요가 되어 있으면 아무 동작도 하지 않음
         }
-
-        // LikeModel 생성
-        LikeModel like = LikeModel.create(userId, product.getId());
-        
-        // 상품의 좋아요 수 증가
-        product.incrementLikesCount();
-        
-        return like;
+        return LikeModel.create(userId, product.getId());
     }
 
     /**
@@ -41,15 +34,8 @@ public class ProductLikeDomainService {
         if (!isLiked(product.getId(), userId)) {
             return null; // 이미 좋아요가 취소되어 있으면 아무 동작도 하지 않음
         }
-
-        // 기존 LikeModel 조회
-        LikeModel like = likeRepository.findByUserIdAndProductId(userId, product.getId())
+        return likeRepository.findByUserIdAndProductId(userId, product.getId())
                 .orElse(null);
-        
-        // 상품의 좋아요 수 감소
-        product.decrementLikesCount();
-        
-        return like;
     }
 
     /**

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/event/ProductLikePublisher.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/event/ProductLikePublisher.java
@@ -1,0 +1,5 @@
+package com.loopers.domain.like.event;
+
+public interface ProductLikePublisher {
+    void publish(ProductLikedEvent event);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/event/ProductLikedEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/event/ProductLikedEvent.java
@@ -1,0 +1,20 @@
+package com.loopers.domain.like.event;
+
+import com.loopers.domain.user.UserId;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.ZonedDateTime;
+
+@Getter
+@RequiredArgsConstructor
+public class ProductLikedEvent {
+
+    private final Long productId;
+    private final UserId userId;
+    private final ZonedDateTime occurredAt;
+
+    public static ProductLikedEvent create(Long productId, UserId userId) {
+        return new ProductLikedEvent(productId, userId, ZonedDateTime.now());
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/event/ProductUnLikePublisher.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/event/ProductUnLikePublisher.java
@@ -1,0 +1,5 @@
+package com.loopers.domain.like.event;
+
+public interface ProductUnLikePublisher {
+    void publish(ProductUnlikedEvent event);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/event/ProductUnlikedEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/event/ProductUnlikedEvent.java
@@ -1,0 +1,21 @@
+package com.loopers.domain.like.event;
+
+import com.loopers.domain.user.UserId;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.ZonedDateTime;
+
+@Getter
+@RequiredArgsConstructor
+public class ProductUnlikedEvent {
+
+    private final Long productId;
+    private final UserId userId;
+    private final ZonedDateTime occurredAt;
+
+    public static ProductUnlikedEvent create(Long productId, UserId userId) {
+        return new ProductUnlikedEvent(productId, userId, ZonedDateTime.now());
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderModel.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderModel.java
@@ -1,7 +1,7 @@
 package com.loopers.domain.order;
 
 import com.loopers.domain.BaseEntity;
-import com.loopers.domain.payment.PaymentMethod;
+import com.loopers.domain.payment.model.PaymentMethod;
 import com.loopers.domain.user.UserId;
 import jakarta.persistence.*;
 import lombok.Getter;
@@ -26,8 +26,6 @@ public class OrderModel extends BaseEntity {
 
     private Money totalAmount;
 
-    private String couponCode;
-
     @Enumerated(EnumType.STRING)
     private OrderStatus status;
 
@@ -40,13 +38,12 @@ public class OrderModel extends BaseEntity {
 
     protected OrderModel() {}
 
-    public static OrderModel create(UserId userId, Money totalAmount, String couponCode, PaymentMethod paymentMethod) {
+    public static OrderModel create(UserId userId, Money totalAmount, PaymentMethod paymentMethod) {
         OrderModel order = new OrderModel();
         order.userId = userId;
         order.orderNumber = OrderNumberGenerator.generateOrderNumber();
         order.orderDate = OrderDate.of(LocalDateTime.now());
         order.totalAmount = totalAmount;
-        order.couponCode = couponCode;
         order.paymentMethod = paymentMethod;
         order.status = OrderStatus.CREATED;
         return order;

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderPricing.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderPricing.java
@@ -1,0 +1,15 @@
+package com.loopers.domain.order;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class OrderPricing {
+    private final Money originalAmount;       // 쿠폰/포인트 이전 총액
+    private final Money couponDiscount;       // 쿠폰으로 절감된 금액
+    private final Money finalAmount;          // 최종 결제 금액
+    private final String couponCode;          // 감사/추적 목적
+}
+
+

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/event/OrderCeatedCouponReserveCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/event/OrderCeatedCouponReserveCommand.java
@@ -1,0 +1,11 @@
+package com.loopers.domain.order.event;
+
+import com.loopers.domain.user.UserId;
+
+public record OrderCeatedCouponReserveCommand(
+        Long orderId, UserId userId, String couponCode
+) {
+    public static OrderCeatedCouponReserveCommand create(Long orderId, UserId userId, String couponCode){
+        return new OrderCeatedCouponReserveCommand(orderId, userId, couponCode);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/event/OrderCreatedCouponReservePublisher.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/event/OrderCreatedCouponReservePublisher.java
@@ -1,0 +1,5 @@
+package com.loopers.domain.order.event;
+
+public interface OrderCreatedCouponReservePublisher {
+    void publish(OrderCeatedCouponReserveCommand command);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/event/OrderCreatedEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/event/OrderCreatedEvent.java
@@ -1,0 +1,34 @@
+package com.loopers.domain.order.event;
+
+import com.loopers.domain.order.Money;
+import com.loopers.domain.order.OrderModel;
+import com.loopers.domain.user.UserId;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
+
+@Getter
+@RequiredArgsConstructor
+public class OrderCreatedEvent {
+
+    private final Long orderId;
+    private final String orderNumber;
+    private final UserId userId;
+    private final Money totalAmount;
+    private final LocalDateTime orderDate;
+    private final ZonedDateTime occurredAt;
+
+
+    public static OrderCreatedEvent from(OrderModel order) {
+        return new OrderCreatedEvent(
+                order.getId(),
+                order.getOrderNumber().getValue(),
+                order.getUserId(),
+                order.getTotalAmount(),
+                order.getOrderDate().getValue(),
+                ZonedDateTime.now()
+        );
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/event/OrderCreatedPublisher.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/event/OrderCreatedPublisher.java
@@ -1,0 +1,5 @@
+package com.loopers.domain.order.event;
+
+public interface OrderCreatedPublisher {
+    void  publish(OrderCreatedEvent event);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/event/OrderCreatedStockDeductionCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/event/OrderCreatedStockDeductionCommand.java
@@ -1,0 +1,15 @@
+package com.loopers.domain.order.event;
+
+import com.loopers.domain.order.OrderItemModel;
+
+import java.util.List;
+
+public record OrderCreatedStockDeductionCommand(
+    List<OrderItemModel> orderItemList
+) {
+    public static OrderCreatedStockDeductionCommand create(
+            List<OrderItemModel> orderItemList
+    ){
+        return new OrderCreatedStockDeductionCommand(orderItemList);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/event/OrderCreatedStockDeductionPublisher.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/event/OrderCreatedStockDeductionPublisher.java
@@ -1,0 +1,5 @@
+package com.loopers.domain.order.event;
+
+public interface OrderCreatedStockDeductionPublisher {
+    void publish(OrderCreatedStockDeductionCommand command);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentData.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentData.java
@@ -1,6 +1,8 @@
 package com.loopers.domain.payment;
 
 import com.loopers.domain.order.Money;
+import com.loopers.domain.payment.model.CardType;
+import com.loopers.domain.payment.model.PaymentMethod;
 import com.loopers.domain.user.UserId;
 
 public record PaymentData(

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentQueryResult.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentQueryResult.java
@@ -1,5 +1,7 @@
 package com.loopers.domain.payment;
 
+import com.loopers.domain.payment.model.PaymentStatus;
+
 public record PaymentQueryResult(
         String transactionKey,
         String orderId,

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/event/PaymentFailedEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/event/PaymentFailedEvent.java
@@ -1,0 +1,26 @@
+package com.loopers.domain.payment.event;
+
+import com.loopers.domain.payment.model.PaymentMethod;
+import com.loopers.domain.payment.model.PaymentModel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.ZonedDateTime;
+
+@Getter
+@RequiredArgsConstructor
+public class PaymentFailedEvent {
+
+    private final Long orderId;
+    private final PaymentMethod paymentMethod;
+    private final String failureReason;
+    private final ZonedDateTime occurredAt;
+
+    public static PaymentFailedEvent create(PaymentModel payment,
+                                            String failureReason) {
+        return new PaymentFailedEvent(
+                payment.getOrderId(), payment.getPaymentMethod(),
+                failureReason,ZonedDateTime.now()
+        );
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/event/PaymentFailedPublisher.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/event/PaymentFailedPublisher.java
@@ -1,0 +1,8 @@
+package com.loopers.domain.payment.event;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public interface PaymentFailedPublisher {
+    void  publish(PaymentFailedEvent event);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/event/PaymentRequestedEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/event/PaymentRequestedEvent.java
@@ -1,0 +1,41 @@
+package com.loopers.domain.payment.event;
+
+import com.loopers.domain.order.Money;
+import com.loopers.domain.payment.model.CardType;
+import com.loopers.domain.payment.model.PaymentMethod;
+import com.loopers.domain.user.UserId;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.ZonedDateTime;
+
+@Getter
+@RequiredArgsConstructor
+public class PaymentRequestedEvent {
+
+    private final Long orderId;
+    private final UserId userId;
+    private final Money totalAmount;
+    private final PaymentMethod paymentMethod;
+    private final String couponCode;
+
+    private final CardType cardType;
+    private final String cardNumber;
+
+    private final Integer pointAmount;
+
+    private final ZonedDateTime occurredAt;
+
+    public static PaymentRequestedEvent forCard(Long orderId, UserId userId, Money totalAmount,
+                                                PaymentMethod paymentMethod, CardType cardType, String cardNumber,
+                                                String couponCode) {
+        return new PaymentRequestedEvent(orderId, userId, totalAmount, paymentMethod, couponCode, cardType, cardNumber, null, ZonedDateTime.now());
+    }
+
+    public static PaymentRequestedEvent forPoint(Long orderId, UserId userId, Money totalAmount,
+                                                 PaymentMethod paymentMethod, Integer pointAmount, String couponCode) {
+        return new PaymentRequestedEvent(orderId, userId, totalAmount, paymentMethod, couponCode, null, null, pointAmount, ZonedDateTime.now());
+    }
+}
+
+

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/event/PaymentRequestedPublisher.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/event/PaymentRequestedPublisher.java
@@ -1,0 +1,5 @@
+package com.loopers.domain.payment.event;
+
+public interface PaymentRequestedPublisher {
+    void publish(PaymentRequestedEvent event);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/event/PaymentSuccessEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/event/PaymentSuccessEvent.java
@@ -1,0 +1,26 @@
+package com.loopers.domain.payment.event;
+
+import com.loopers.domain.payment.model.PaymentMethod;
+import com.loopers.domain.payment.model.PaymentModel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.ZonedDateTime;
+
+@Getter
+@RequiredArgsConstructor
+public class PaymentSuccessEvent {
+
+    private final Long orderId;
+    private final Long paymentId;
+    private final PaymentMethod paymentMethod;
+    private final String transactionKey;
+    private final ZonedDateTime occurredAt;
+
+    public static PaymentSuccessEvent create(PaymentModel payment,
+                                             String transactionKey) {
+        return new PaymentSuccessEvent(
+                payment.getOrderId(), payment.getId(), payment.getPaymentMethod(), transactionKey, ZonedDateTime.now()
+        );
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/event/PaymentSuccessPublisher.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/event/PaymentSuccessPublisher.java
@@ -1,0 +1,8 @@
+package com.loopers.domain.payment.event;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public interface PaymentSuccessPublisher {
+    void publish(PaymentSuccessEvent event);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/model/CardPayment.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/model/CardPayment.java
@@ -1,6 +1,7 @@
-package com.loopers.domain.payment;
+package com.loopers.domain.payment.model;
 
 import com.loopers.domain.BaseEntity;
+import com.loopers.domain.payment.PaymentData;
 import com.loopers.domain.user.UserId;
 import jakarta.persistence.*;
 import lombok.Getter;

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/model/CardType.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/model/CardType.java
@@ -1,4 +1,4 @@
-package com.loopers.domain.payment;
+package com.loopers.domain.payment.model;
 
 public enum CardType {
     SAMSUNG,

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/model/PaymentMethod.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/model/PaymentMethod.java
@@ -1,4 +1,4 @@
-package com.loopers.domain.payment;
+package com.loopers.domain.payment.model;
 
 public enum PaymentMethod {
     CREDIT_CARD,

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/model/PaymentModel.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/model/PaymentModel.java
@@ -1,4 +1,4 @@
-package com.loopers.domain.payment;
+package com.loopers.domain.payment.model;
 
 import com.loopers.domain.BaseEntity;
 import com.loopers.domain.order.Money;

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/model/PaymentStatus.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/model/PaymentStatus.java
@@ -1,4 +1,4 @@
-package com.loopers.domain.payment;
+package com.loopers.domain.payment.model;
 
 public enum PaymentStatus {
     PENDING,

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/model/PointPayment.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/model/PointPayment.java
@@ -1,4 +1,4 @@
-package com.loopers.domain.payment;
+package com.loopers.domain.payment.model;
 
 import com.loopers.domain.BaseEntity;
 import com.loopers.domain.point.PointModel;

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/repository/CardPaymentRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/repository/CardPaymentRepository.java
@@ -1,5 +1,6 @@
-package com.loopers.domain.payment;
+package com.loopers.domain.payment.repository;
 
+import com.loopers.domain.payment.model.CardPayment;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/repository/PaymentRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/repository/PaymentRepository.java
@@ -1,4 +1,7 @@
-package com.loopers.domain.payment;
+package com.loopers.domain.payment.repository;
+
+import com.loopers.domain.payment.model.PaymentModel;
+import com.loopers.domain.payment.model.PaymentStatus;
 
 import java.time.ZonedDateTime;
 import java.util.List;

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/repository/PointPaymentRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/repository/PointPaymentRepository.java
@@ -1,5 +1,6 @@
-package com.loopers.domain.payment;
+package com.loopers.domain.payment.repository;
 
+import com.loopers.domain.payment.model.PointPayment;
 import org.springframework.stereotype.Repository;
 
 @Repository

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/event/ChangeType.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/event/ChangeType.java
@@ -1,0 +1,5 @@
+package com.loopers.domain.product.event;
+
+public enum ChangeType {
+    CREATED, UPDATED, DELETED
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/event/ClickContext.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/event/ClickContext.java
@@ -1,0 +1,5 @@
+package com.loopers.domain.product.event;
+
+public enum ClickContext {
+    MAIN_LIST, CATEGORY_LIST, SEARCH_RESULT, RECOMMENDATION
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/event/ProductChangedEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/event/ProductChangedEvent.java
@@ -1,0 +1,16 @@
+package com.loopers.domain.product.event;
+
+import lombok.Getter;
+
+@Getter
+public class ProductChangedEvent {
+
+    private final Long productId;
+    private final ChangeType changeType;
+
+    public ProductChangedEvent(Long productId, ChangeType changeType) {
+        this.productId = productId;
+        this.changeType = changeType;
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/event/ProductChangedPublisher.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/event/ProductChangedPublisher.java
@@ -1,0 +1,5 @@
+package com.loopers.domain.product.event;
+
+public interface ProductChangedPublisher {
+    void publishEvent(ProductViewedEvent event);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/event/ProductClickedEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/event/ProductClickedEvent.java
@@ -1,0 +1,27 @@
+package com.loopers.domain.product.event;
+
+import com.loopers.domain.user.UserId;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.ZonedDateTime;
+
+@Getter
+@RequiredArgsConstructor
+public class ProductClickedEvent {
+
+    private final Long productId;
+    private final UserId userId;
+    private final ClickContext clickContext;
+    private final Integer position; // 목록에서의 위치
+    private final ZonedDateTime occurredAt;
+
+    public static ProductClickedEvent create(Long productId, UserId userId, ClickContext clickContext) {
+        return new ProductClickedEvent(productId, userId, clickContext, null, ZonedDateTime.now());
+    }
+
+    public static ProductClickedEvent create(Long productId, UserId userId, ClickContext clickContext, Integer position) {
+        return new ProductClickedEvent(productId, userId, clickContext, position, ZonedDateTime.now());
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/event/ProductClickedPublisher.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/event/ProductClickedPublisher.java
@@ -1,0 +1,8 @@
+package com.loopers.domain.product.event;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public interface ProductClickedPublisher {
+    void publish(ProductClickedEvent event);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/event/ProductDetailViewedPublisher.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/event/ProductDetailViewedPublisher.java
@@ -1,0 +1,8 @@
+package com.loopers.domain.product.event;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public interface ProductDetailViewedPublisher {
+    void publish(ProductViewedEvent event);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/event/ProductViewedEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/event/ProductViewedEvent.java
@@ -1,0 +1,31 @@
+package com.loopers.domain.product.event;
+
+import com.loopers.domain.user.UserId;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.ZonedDateTime;
+
+@Getter
+@RequiredArgsConstructor
+public class ProductViewedEvent {
+
+    private final Long productId;
+    private final UserId userId;
+    private final ViewType viewType;
+    private final String referrer; // 어디서 왔는지
+    private final ZonedDateTime occurredAt;
+
+    public static ProductViewedEvent createDetailView(Long productId, UserId userId) {
+        return new ProductViewedEvent(productId, userId, ViewType.DETAIL, null, ZonedDateTime.now());
+    }
+
+    public static ProductViewedEvent createListView(Long productId, UserId userId, String referrer) {
+        return new ProductViewedEvent(productId, userId, ViewType.LIST, referrer, ZonedDateTime.now());
+    }
+
+    public static ProductViewedEvent createSearchView(Long productId, UserId userId, String searchQuery) {
+        return new ProductViewedEvent(productId, userId, ViewType.SEARCH, searchQuery, ZonedDateTime.now());
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/event/ViewType.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/event/ViewType.java
@@ -1,0 +1,5 @@
+package com.loopers.domain.product.event;
+
+public enum ViewType {
+    DETAIL, LIST, SEARCH
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/event/UserActionData.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/event/UserActionData.java
@@ -1,0 +1,27 @@
+package com.loopers.domain.user.event;
+
+import com.loopers.domain.user.UserId;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.ZonedDateTime;
+
+@Getter
+@RequiredArgsConstructor
+public class UserActionData {
+
+    private final UserId userId;
+    private final UserActionType actionType;
+    private final Long targetId;
+    private final String additionalInfo;
+    private final ZonedDateTime timestamp;
+
+    public static UserActionData create(UserId userId, UserActionType actionType, Long targetId) {
+        return new UserActionData(userId, actionType, targetId, null, ZonedDateTime.now());
+    }
+
+    public static UserActionData create(UserId userId, UserActionType actionType, Long targetId, String additionalInfo) {
+        return new UserActionData(userId, actionType, targetId, additionalInfo, ZonedDateTime.now());
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/event/UserActionTrackingPort.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/event/UserActionTrackingPort.java
@@ -1,0 +1,7 @@
+package com.loopers.domain.user.event;
+
+public interface UserActionTrackingPort {
+
+    void trackUserAction(UserActionData actionData);
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/event/UserActionType.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/event/UserActionType.java
@@ -6,7 +6,9 @@ public enum UserActionType {
     PRODUCT_LIKE("상품 좋아요"),
     PRODUCT_UNLIKE("상품 좋아요 취소"),
     ORDER_CREATE("주문 생성"),
-    ORDER_CANCEL("주문 취소");
+    ORDER_CANCEL("주문 취소"),
+    PAYMENT_SUCCESS("결제 성공"),
+    PAYMENT_FAILURE("결제 실패");
 
     private final String description;
 

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/event/UserActionType.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/event/UserActionType.java
@@ -1,0 +1,20 @@
+package com.loopers.domain.user.event;
+
+public enum UserActionType {
+    PRODUCT_VIEW("상품 조회"),
+    PRODUCT_CLICK("상품 클릭"),
+    PRODUCT_LIKE("상품 좋아요"),
+    PRODUCT_UNLIKE("상품 좋아요 취소"),
+    ORDER_CREATE("주문 생성"),
+    ORDER_CANCEL("주문 취소");
+
+    private final String description;
+
+    UserActionType(String description) {
+        this.description = description;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/UserCouponJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/UserCouponJpaRepository.java
@@ -9,5 +9,6 @@ import java.util.Optional;
 public interface UserCouponJpaRepository extends JpaRepository<UserCouponModel, Long> {
 
     Optional<UserCouponModel> findByUserIdAndCouponCode(UserId userId, String couponCode);
-    
+
+    Optional<UserCouponModel> findByOrderId(Long orderId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/UserCouponRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/UserCouponRepositoryImpl.java
@@ -23,4 +23,9 @@ public class UserCouponRepositoryImpl implements UserCouponRepository {
     public UserCouponModel save(UserCouponModel userCoupon) {
         return userCouponJpaRepository.save(userCoupon);
     }
+
+    @Override
+    public Optional<UserCouponModel> findByOrderId(Long orderId) {
+        return userCouponJpaRepository.findByOrderId(orderId);
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/external/DataPlatformClientAdapter.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/external/DataPlatformClientAdapter.java
@@ -1,19 +1,20 @@
 package com.loopers.infrastructure.external;
 
 import com.loopers.domain.external.DataPlatformPort;
-import com.loopers.domain.order.event.OrderCreatedEvent;
 import com.loopers.domain.external.DataPlatformResult;
-import com.loopers.domain.user.UserId;
+import com.loopers.domain.order.event.OrderCreatedEvent;
+import com.loopers.domain.payment.event.PaymentFailedEvent;
+import com.loopers.domain.payment.event.PaymentSuccessEvent;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
-import java.time.ZonedDateTime;
 import java.util.HashMap;
 import java.util.Map;
 
 @Slf4j
 @Component
 public class DataPlatformClientAdapter implements DataPlatformPort {
+
     @Override
     public DataPlatformResult sendOrderData(OrderCreatedEvent event) {
         try {
@@ -25,16 +26,14 @@ public class DataPlatformClientAdapter implements DataPlatformPort {
             orderData.put("order_number", event.getOrderNumber());
             orderData.put("user_id", event.getUserId().getValue());
             orderData.put("amount", event.getTotalAmount().getAmount());
-            // 결제 방식과 쿠폰 코드는 이벤트에서 제공되지 않음
             orderData.put("order_date", event.getOrderDate().toString());
             orderData.put("sent_at", event.getOccurredAt().toString());
 
             log.debug("📊 [Data Platform] 전송 데이터: {}", orderData);
 
-            String transactionKey = "TXN-" + System.currentTimeMillis();
-            log.info("📊 [Data Platform] 주문 데이터 전송 완료 - transactionKey: {}", transactionKey);
+            log.info("📊 [Data Platform] 주문 데이터 전송 완료 - order_id: {}", event.getOrderId());
 
-            return DataPlatformResult.success(transactionKey);
+            return DataPlatformResult.success(null);
 
         } catch (Exception e) {
             log.error("📊 [Data Platform] 주문 데이터 전송 실패 - OrderId: {}, Error: {}",
@@ -44,11 +43,51 @@ public class DataPlatformClientAdapter implements DataPlatformPort {
     }
 
     @Override
-    public void sendUserActionData(UserId userId, String action, Long targetId, ZonedDateTime timestamp) {
-        log.info("📊 [Data Platform] 사용자 행동 데이터 전송 - UserId: {}, Action: {}, TargetId: {}",
-                userId.getValue(), action, targetId);
+    public DataPlatformResult sendPaymentSuccess(PaymentSuccessEvent event) {
+        try {
+            log.info("📊 [Data Platform] 결제 성공 결과 데이터 전송 - OrderId: {}, PaymentId: {}, PaymentMethod: {}",
+                    event.getOrderId(), event.getPaymentId(), event.getPaymentMethod());
 
+            Map<String, Object> paymentData = new HashMap<>();
+            paymentData.put("order_id", event.getOrderId());
+            paymentData.put("payment_id", event.getPaymentId());
+            paymentData.put("payment_method", event.getPaymentMethod());
+            paymentData.put("sent_at", event.getOccurredAt().toString());
 
+            log.debug("📊 [Data Platform] 전송 데이터: {}", paymentData);
 
+            log.info("📊 [Data Platform] 결제 성공 결과 데이터 전송 완료 - transactionKey: {}", event.getTransactionKey());
+
+            return DataPlatformResult.success(event.getTransactionKey());
+
+        } catch (Exception e) {
+            log.error("📊 [Data Platform] 결제 결과 데이터 전송 실패 - OrderId: {}, Error: {}",
+                    event.getOrderId(), e.getMessage(), e);
+            return DataPlatformResult.failed("데이터 전송 실패: " + e.getMessage());
+        }
     }
+
+    @Override
+    public DataPlatformResult sendPaymentFailure(PaymentFailedEvent event) {
+        try {
+            log.info("📊 [Data Platform] 결제 실패 결과 데이터 전송 - OrderId: {}, PaymentMethod: {}, Reason: {}",
+                    event.getOrderId(), event.getPaymentMethod(), event.getFailureReason());
+
+            Map<String, Object> paymentData = new HashMap<>();
+            paymentData.put("order_id", event.getOrderId());
+            paymentData.put("payment_method", event.getPaymentMethod());
+            paymentData.put("failure_reason", event.getFailureReason());
+            paymentData.put("sent_at", event.getOccurredAt().toString());
+
+            log.debug("📊 [Data Platform] 전송 데이터: {}", paymentData);
+
+            return DataPlatformResult.success(null);
+
+        } catch (Exception e) {
+            log.error("📊 [Data Platform] 결제 결과 데이터 전송 실패 - OrderId: {}, Error: {}",
+                    event.getOrderId(), e.getMessage(), e);
+            return DataPlatformResult.failed("데이터 전송 실패: " + e.getMessage());
+        }
+    }
+
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/external/DataPlatformClientAdapter.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/external/DataPlatformClientAdapter.java
@@ -1,0 +1,54 @@
+package com.loopers.infrastructure.external;
+
+import com.loopers.domain.external.DataPlatformPort;
+import com.loopers.domain.order.event.OrderCreatedEvent;
+import com.loopers.domain.external.DataPlatformResult;
+import com.loopers.domain.user.UserId;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.time.ZonedDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@Component
+public class DataPlatformClientAdapter implements DataPlatformPort {
+    @Override
+    public DataPlatformResult sendOrderData(OrderCreatedEvent event) {
+        try {
+            log.info("📊 [Data Platform] 주문 데이터 전송 - OrderId: {}, UserId: {}, Amount: {}",
+                    event.getOrderId(), event.getUserId().getValue(), event.getTotalAmount().getAmount());
+
+            Map<String, Object> orderData = new HashMap<>();
+            orderData.put("order_id", event.getOrderId());
+            orderData.put("order_number", event.getOrderNumber());
+            orderData.put("user_id", event.getUserId().getValue());
+            orderData.put("amount", event.getTotalAmount().getAmount());
+            // 결제 방식과 쿠폰 코드는 이벤트에서 제공되지 않음
+            orderData.put("order_date", event.getOrderDate().toString());
+            orderData.put("sent_at", event.getOccurredAt().toString());
+
+            log.debug("📊 [Data Platform] 전송 데이터: {}", orderData);
+
+            String transactionKey = "TXN-" + System.currentTimeMillis();
+            log.info("📊 [Data Platform] 주문 데이터 전송 완료 - transactionKey: {}", transactionKey);
+
+            return DataPlatformResult.success(transactionKey);
+
+        } catch (Exception e) {
+            log.error("📊 [Data Platform] 주문 데이터 전송 실패 - OrderId: {}, Error: {}",
+                    event.getOrderId(), e.getMessage(), e);
+            return DataPlatformResult.failed("데이터 전송 실패: " + e.getMessage());
+        }
+    }
+
+    @Override
+    public void sendUserActionData(UserId userId, String action, Long targetId, ZonedDateTime timestamp) {
+        log.info("📊 [Data Platform] 사용자 행동 데이터 전송 - UserId: {}, Action: {}, TargetId: {}",
+                userId.getValue(), action, targetId);
+
+
+
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/http/PgClientAdapter.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/http/PgClientAdapter.java
@@ -1,6 +1,7 @@
 package com.loopers.infrastructure.http;
 
 import com.loopers.domain.payment.*;
+import com.loopers.domain.payment.model.PaymentStatus;
 import feign.FeignException;
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import io.github.resilience4j.retry.annotation.Retry;

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/ProductLikePublisherImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/ProductLikePublisherImpl.java
@@ -1,0 +1,19 @@
+package com.loopers.infrastructure.like;
+
+import com.loopers.domain.like.event.ProductLikePublisher;
+import com.loopers.domain.like.event.ProductLikedEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ProductLikePublisherImpl implements ProductLikePublisher {
+
+    private final ApplicationEventPublisher applicationEventPublisher;
+
+    @Override
+    public void publish(ProductLikedEvent event) {
+        applicationEventPublisher.publishEvent(event);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/ProductUnlikePublisherImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/ProductUnlikePublisherImpl.java
@@ -1,0 +1,19 @@
+package com.loopers.infrastructure.like;
+
+import com.loopers.domain.like.event.ProductUnLikePublisher;
+import com.loopers.domain.like.event.ProductUnlikedEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ProductUnlikePublisherImpl implements ProductUnLikePublisher {
+
+    private final ApplicationEventPublisher applicationEventPublisher;
+
+    @Override
+    public void publish(ProductUnlikedEvent event) {
+        applicationEventPublisher.publishEvent(event);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/order/OrderCreatedCouponReservePublisherImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/order/OrderCreatedCouponReservePublisherImpl.java
@@ -1,0 +1,19 @@
+package com.loopers.infrastructure.order;
+
+import com.loopers.domain.order.event.OrderCeatedCouponReserveCommand;
+import com.loopers.domain.order.event.OrderCreatedCouponReservePublisher;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class OrderCreatedCouponReservePublisherImpl implements OrderCreatedCouponReservePublisher {
+
+    private final ApplicationEventPublisher applicationEventPublisher;
+
+    @Override
+    public void publish(OrderCeatedCouponReserveCommand command) {
+        applicationEventPublisher.publishEvent(command);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/order/OrderCreatedPublisherImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/order/OrderCreatedPublisherImpl.java
@@ -1,0 +1,19 @@
+package com.loopers.infrastructure.order;
+
+import com.loopers.domain.order.event.OrderCreatedEvent;
+import com.loopers.domain.order.event.OrderCreatedPublisher;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class OrderCreatedPublisherImpl implements OrderCreatedPublisher {
+
+    private final ApplicationEventPublisher applicationEventPublisher;
+
+    @Override
+    public void publish(OrderCreatedEvent event) {
+        applicationEventPublisher.publishEvent(event);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/order/OrderCreatedStockDeductionPublisherImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/order/OrderCreatedStockDeductionPublisherImpl.java
@@ -1,0 +1,19 @@
+package com.loopers.infrastructure.order;
+
+import com.loopers.domain.order.event.OrderCreatedStockDeductionCommand;
+import com.loopers.domain.order.event.OrderCreatedStockDeductionPublisher;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class OrderCreatedStockDeductionPublisherImpl implements OrderCreatedStockDeductionPublisher {
+
+    private final ApplicationEventPublisher eventPublisher;
+
+    @Override
+    public void publish(OrderCreatedStockDeductionCommand command) {
+        eventPublisher.publishEvent(command);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/CardPaymentJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/CardPaymentJpaRepository.java
@@ -1,6 +1,6 @@
 package com.loopers.infrastructure.payment;
 
-import com.loopers.domain.payment.CardPayment;
+import com.loopers.domain.payment.model.CardPayment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/CardPaymentRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/CardPaymentRepositoryImpl.java
@@ -1,7 +1,7 @@
 package com.loopers.infrastructure.payment;
 
-import com.loopers.domain.payment.CardPayment;
-import com.loopers.domain.payment.CardPaymentRepository;
+import com.loopers.domain.payment.model.CardPayment;
+import com.loopers.domain.payment.repository.CardPaymentRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentFailedPublisherImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentFailedPublisherImpl.java
@@ -1,0 +1,19 @@
+package com.loopers.infrastructure.payment;
+
+import com.loopers.domain.payment.event.PaymentFailedEvent;
+import com.loopers.domain.payment.event.PaymentFailedPublisher;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PaymentFailedPublisherImpl implements PaymentFailedPublisher {
+
+    private final ApplicationEventPublisher applicationEventPublisher;
+
+    @Override
+    public void publish(PaymentFailedEvent event) {
+        applicationEventPublisher.publishEvent(event);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentJpaRepository.java
@@ -1,7 +1,7 @@
 package com.loopers.infrastructure.payment;
 
-import com.loopers.domain.payment.PaymentModel;
-import com.loopers.domain.payment.PaymentStatus;
+import com.loopers.domain.payment.model.PaymentModel;
+import com.loopers.domain.payment.model.PaymentStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.ZonedDateTime;

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentRepositoryImpl.java
@@ -1,8 +1,8 @@
 package com.loopers.infrastructure.payment;
 
-import com.loopers.domain.payment.PaymentModel;
-import com.loopers.domain.payment.PaymentRepository;
-import com.loopers.domain.payment.PaymentStatus;
+import com.loopers.domain.payment.model.PaymentModel;
+import com.loopers.domain.payment.repository.PaymentRepository;
+import com.loopers.domain.payment.model.PaymentStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentRequestedPublisherImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentRequestedPublisherImpl.java
@@ -1,0 +1,19 @@
+package com.loopers.infrastructure.payment;
+
+import com.loopers.domain.payment.event.PaymentRequestedEvent;
+import com.loopers.domain.payment.event.PaymentRequestedPublisher;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PaymentRequestedPublisherImpl implements PaymentRequestedPublisher {
+
+    private final ApplicationEventPublisher applicationEventPublisher;
+
+    @Override
+    public void publish(PaymentRequestedEvent event) {
+        applicationEventPublisher.publishEvent(event);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentSuccessPublisherImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentSuccessPublisherImpl.java
@@ -1,0 +1,19 @@
+package com.loopers.infrastructure.payment;
+
+import com.loopers.domain.payment.event.PaymentSuccessEvent;
+import com.loopers.domain.payment.event.PaymentSuccessPublisher;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PaymentSuccessPublisherImpl implements PaymentSuccessPublisher {
+
+    private final ApplicationEventPublisher applicationEventPublisher;
+
+    @Override
+    public void publish(PaymentSuccessEvent event) {
+        applicationEventPublisher.publishEvent(event);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PointPaymentJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PointPaymentJpaRepository.java
@@ -1,6 +1,6 @@
 package com.loopers.infrastructure.payment;
 
-import com.loopers.domain.payment.PointPayment;
+import com.loopers.domain.payment.model.PointPayment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PointPaymentJpaRepository extends JpaRepository<PointPayment, Long> {

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PointPaymentRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PointPaymentRepositoryImpl.java
@@ -1,7 +1,7 @@
 package com.loopers.infrastructure.payment;
 
-import com.loopers.domain.payment.PointPayment;
-import com.loopers.domain.payment.PointPaymentRepository;
+import com.loopers.domain.payment.model.PointPayment;
+import com.loopers.domain.payment.repository.PointPaymentRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductChangedPublisherImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductChangedPublisherImpl.java
@@ -1,0 +1,19 @@
+package com.loopers.infrastructure.product;
+
+import com.loopers.domain.product.event.ProductChangedPublisher;
+import com.loopers.domain.product.event.ProductViewedEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ProductChangedPublisherImpl implements ProductChangedPublisher {
+
+    private final ApplicationEventPublisher eventPublisher;
+
+    @Override
+    public void publishEvent(ProductViewedEvent event) {
+        eventPublisher.publishEvent(event);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/userTracking/UserActionTrackingAdapter.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/userTracking/UserActionTrackingAdapter.java
@@ -1,0 +1,64 @@
+package com.loopers.infrastructure.userTracking;
+
+import com.loopers.domain.user.event.UserActionData;
+import com.loopers.domain.user.event.UserActionTrackingPort;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@Component
+public class UserActionTrackingAdapter implements UserActionTrackingPort {
+
+
+    @Override
+    public void trackUserAction(UserActionData actionData) {
+        try {
+            log.info("📊 [UserActionTracking] 사용자 행동 추적 - UserId: {}, Action: {}, TargetId: {}",
+                    actionData.getUserId().getValue(),
+                    actionData.getActionType().getDescription(),
+                    actionData.getTargetId());
+
+            Map<String, Object> trackingData = new HashMap<>();
+            trackingData.put("user_id", actionData.getUserId().getValue());
+            trackingData.put("action_type", actionData.getActionType().name());
+            trackingData.put("action_description", actionData.getActionType().getDescription());
+            trackingData.put("target_id", actionData.getTargetId());
+            trackingData.put("additional_info", actionData.getAdditionalInfo());
+            trackingData.put("timestamp", actionData.getTimestamp().toString());
+            trackingData.put("session_id", generateSessionId()); // 세션 추적
+            trackingData.put("device_info", getDeviceInfo()); // 디바이스 정보
+
+            log.debug("📊 [UserActionTracking] 추적 데이터: {}", trackingData);
+
+            sendToAnalyticsPlatform(trackingData);
+
+        } catch (Exception e) {
+            log.error("📊 [UserActionTracking] 사용자 행동 추적 실패 - UserId: {}, Error: {}",
+                    actionData.getUserId().getValue(), e.getMessage(), e);
+        }
+    }
+
+    /**
+     * 데이터 플랫폼으로 트래킹 정보 전송 (Mock)
+     */
+    private void sendToAnalyticsPlatform(Map<String, Object> trackingData) {
+        log.info("ANALYTICS: {}", trackingData);
+    }
+    /**
+     * 세션 ID 생성 (Mock)
+     */
+    private String generateSessionId() {
+        return "SESSION-" + System.currentTimeMillis();
+    }
+
+    /**
+     * 디바이스 정보 추출 (Mock)
+     */
+    private String getDeviceInfo() {
+        return "WEB";
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/event/EventV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/event/EventV1ApiSpec.java
@@ -1,0 +1,11 @@
+package com.loopers.interfaces.api.event;
+
+import com.loopers.interfaces.api.ApiResponse;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+public interface EventV1ApiSpec {
+
+    ApiResponse<?> handleProductClick(@RequestHeader(value = "X-USER-ID", required = false) String userId, @RequestBody EventV1Dto.ProductClickRequest request);
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/event/EventV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/event/EventV1Controller.java
@@ -1,0 +1,25 @@
+package com.loopers.interfaces.api.event;
+
+import com.loopers.domain.product.event.ProductClickedEvent;
+import com.loopers.domain.product.event.ProductClickedPublisher;
+import com.loopers.domain.user.UserId;
+import com.loopers.interfaces.api.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/events")
+public class EventV1Controller implements EventV1ApiSpec {
+
+    private final ProductClickedPublisher eventPublisher;
+
+    @PostMapping("/click")
+    public ApiResponse<?> handleProductClick(String userId, EventV1Dto.ProductClickRequest request) {
+        if (userId != null) {
+            eventPublisher.publish(ProductClickedEvent.create(request.productId(), UserId.of(userId), request.context()));
+        }
+        return ApiResponse.success();
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/event/EventV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/event/EventV1Dto.java
@@ -1,0 +1,15 @@
+package com.loopers.interfaces.api.event;
+
+import com.loopers.domain.product.event.ClickContext;
+
+public class EventV1Dto {
+
+
+    public record ProductClickRequest(Long productId, ClickContext context) {
+
+        public EventV1Dto.ProductClickRequest create() {
+            return new EventV1Dto.ProductClickRequest(productId, context);
+        }
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/order/OrderV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/order/OrderV1Controller.java
@@ -5,7 +5,8 @@ import com.loopers.application.order.OrderCommand;
 import com.loopers.application.order.OrderInfo;
 import com.loopers.application.payment.PaymentApplicationService;
 import com.loopers.interfaces.api.ApiResponse;
-import com.loopers.support.error.PaymentFailedException;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
@@ -17,61 +18,37 @@ import org.springframework.web.bind.annotation.*;
 public class OrderV1Controller implements OrderV1ApiSpec {
 
     private final PaymentApplicationService paymentApplicationService;
-    private final OrderApplicationService orderApplicationService;
+	private final OrderApplicationService orderApplicationService;
 
-    @Override
-    @PostMapping
-    public ApiResponse<OrderV1Dto.CreateOrderResponse> createOrder(@RequestHeader("X-USER-ID") String userId, @RequestBody OrderV1Dto.CreateOrderRequest request) {
-        try {
-            log.info("주문 생성 시작 - User: {}, Payment: {}", userId, request.paymentMethod());
+	@Override
+	@PostMapping
+	public ApiResponse<OrderV1Dto.CreateOrderResponse> createOrder(@RequestHeader("X-USER-ID") String userId, @RequestBody OrderV1Dto.CreateOrderRequest request) {
+		try {
+			request.validate();
+			OrderCommand command = request.toCommand(userId);
 
-            // 요청 검증
-            request.validate();
-
-            OrderCommand command = request.toCommand(userId);
-            log.info("주문 명령 생성 완료 - Command: {}", command);
-
-            // 주문 생성
+			// 주문 생성
             OrderInfo orderInfo = orderApplicationService.createOrder(command);
-            log.info("주문 생성 완료 - OrderId: {}", orderInfo.orderId());
 
             // 결제 요청
             try {
                 switch (request.paymentMethod()) {
-                    case CREDIT_CARD -> {
-                        log.info("카드 결제 처리 시작 - OrderId: {}", orderInfo.orderId());
-                        try {
-                            paymentApplicationService.processCardPayment(
+                    case CREDIT_CARD -> paymentApplicationService.processCardPayment(
                                     orderInfo, request.paymentMethod(), request.cardType(), request.cardNumber());
-                            log.info("카드 결제 처리 완료 - OrderId: {}", orderInfo.orderId());
-                        } catch (Exception e) {
-                            log.error("카드 결제 처리 실패 - OrderId: {}, Error: {}", orderInfo.orderId(), e.getMessage(), e);
-                            // 결제 실패 시 주문 취소 처리
-                            paymentApplicationService.handlePaymentFailure(orderInfo.orderId());
-                            throw new PaymentFailedException("카드 결제에 실패했습니다: " + e.getMessage());
-                        }
-                    }
-                    case POINT -> {
-                        log.info("포인트 결제 처리 시작 - OrderId: {}", orderInfo.orderId());
-                        paymentApplicationService.processPointPayment(
+                    case POINT -> paymentApplicationService.processPointPayment(
                                 orderInfo, request.paymentMethod(), request.pointAmount());
-                        log.info("포인트 결제 처리 완료 - OrderId: {}", orderInfo.orderId());
-                    }
                     default -> throw new IllegalArgumentException("지원하지 않는 결제 방법입니다: " + request.paymentMethod());
                 }
             } catch (Exception e) {
                 log.error("결제 처리 실패 - OrderId: {}, Error: {}", orderInfo.orderId(), e.getMessage(), e);
-                // 결제 실패 시 주문을 취소 상태로 변경하거나 적절한 처리 필요
-                return ApiResponse.fail("PAYMENT_FAILED", "결제 처리에 실패했습니다: " + e.getMessage(), OrderV1Dto.CreateOrderResponse.class);
+                throw new CoreException(ErrorType.PAYMENT_FAILED, "결제 처리에 실패했습니다: " + e.getMessage());
             }
-
             OrderV1Dto.CreateOrderResponse response = OrderV1Dto.CreateOrderResponse.from(orderInfo);
-            log.info("주문 생성 및 결제 완료 - OrderId: {}, Response: {}", orderInfo.orderId(), response);
-            return ApiResponse.success(response);
+			return ApiResponse.success(response);
 
-        } catch (Exception e) {
-            log.error("주문 생성 실패 - User: {}, Error: {}", userId, e.getMessage(), e);
-            return ApiResponse.fail("ORDER_CREATION_FAILED", "주문 생성에 실패했습니다: " + e.getMessage(), OrderV1Dto.CreateOrderResponse.class);
-        }
-    }
+		} catch (Exception e) {
+			log.error("주문 생성 실패 - User: {}, Error: {}", userId, e.getMessage(), e);
+            throw new CoreException(ErrorType.ORDER_CREATION_FAILED, "주문 생성에 실패했습니다: " + e.getMessage());
+		}
+	}
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/order/OrderV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/order/OrderV1Dto.java
@@ -4,8 +4,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.loopers.application.order.OrderCommand;
 import com.loopers.application.order.OrderInfo;
 import com.loopers.application.order.OrderItemCommand;
-import com.loopers.domain.payment.CardType;
-import com.loopers.domain.payment.PaymentMethod;
+import com.loopers.domain.payment.model.CardType;
+import com.loopers.domain.payment.model.PaymentMethod;
 import com.loopers.domain.user.UserId;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
@@ -16,6 +16,10 @@ import java.util.List;
 public class OrderV1Dto {
 
     public record CreateOrderRequest(
+
+            @JsonProperty("user_id")
+            @Parameter(description = "사용자 ID", example = "user123")
+            String userId,
 
             @JsonProperty("payment_method")
             @Parameter(description = "결제 방법", example = "CREDIT_CARD")

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/payment/PaymentV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/payment/PaymentV1Dto.java
@@ -1,6 +1,6 @@
 package com.loopers.interfaces.api.payment;
 
-import com.loopers.domain.payment.PaymentStatus;
+import com.loopers.domain.payment.model.PaymentStatus;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1ApiSpec.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
 
 @Tag(name = "Product V1 API", description = "상품 조회 API")
 public interface ProductV1ApiSpec {
@@ -14,12 +15,14 @@ public interface ProductV1ApiSpec {
     @GetMapping
     @Operation(summary = "상품 목록 조회", description = "브랜드, 카테고리 필터링 및 정렬 기능을 제공합니다.")
     ApiResponse<ProductV1Dto.ProductListResponse> getProductList(
+            @RequestHeader(value = "X-USER-ID", required = false) String userId,
             @ModelAttribute ProductV1Dto.ProductListRequest productListRequest
     );
 
     @GetMapping("/{productId}")
     @Operation(summary = "상품 상세 조회", description = "상품 ID로 상품 상세 정보를 조회합니다.")
     ApiResponse<ProductV1Dto.ProductResponseDto> getProductDetail(
+            @RequestHeader(value = "X-USER-ID", required = false) String userId,
             @Parameter(description = "상품 ID") @PathVariable(value = "productId") Long productId
     );
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Controller.java
@@ -7,6 +7,7 @@ import com.loopers.interfaces.api.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -22,7 +23,9 @@ public class ProductV1Controller implements ProductV1ApiSpec {
 
     @Override
     @GetMapping
-    public ApiResponse<ProductV1Dto.ProductListResponse> getProductList(ProductV1Dto.ProductListRequest request) {
+    public ApiResponse<ProductV1Dto.ProductListResponse> getProductList(
+            @RequestHeader(value = "X-USER-ID", required = false) String userId,
+            ProductV1Dto.ProductListRequest request) {
 
         log.info("상품 목록 조회 요청 - productName: {}, brandId: {}, categoryId: {}, sortBy: {}, pageSize: {}, lastId: {}, lastLikesCount: {}, lastPrice: {}, lastCreatedAt: {}",
                 request.productName(), request.brandId(), request.categoryId(), request.sortBy(), request.pageSize(),
@@ -44,9 +47,10 @@ public class ProductV1Controller implements ProductV1ApiSpec {
     @Override
     @GetMapping("/{productId}")
     public ApiResponse<ProductV1Dto.ProductResponseDto> getProductDetail(
+            @RequestHeader(value = "X-USER-ID", required = false) String userId,
             Long productId) {
 
-        ProductOutputInfo product = productApplicationService.getProductDetail(productId);
+        ProductOutputInfo product = productApplicationService.getProductDetail(productId, userId);
         ProductV1Dto.ProductResponseDto responseBody = ProductV1Dto.ProductResponseDto.from(
                 product.id(), product.name(), product.brandName(), product.categoryName(),
                 product.price(), product.likeCount(), product.stock()

--- a/apps/commerce-api/src/main/java/com/loopers/support/async/config/AsyncConfig.java
+++ b/apps/commerce-api/src/main/java/com/loopers/support/async/config/AsyncConfig.java
@@ -1,0 +1,27 @@
+package com.loopers.support.async.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+    @Bean("eventTaskExecutor")
+    public Executor eventTaskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(5);
+        executor.setMaxPoolSize(10);
+        executor.setQueueCapacity(25);
+        executor.setThreadNamePrefix("Event-");
+        executor.setWaitForTasksToCompleteOnShutdown(true);
+        executor.setAwaitTerminationSeconds(30);
+        executor.initialize();
+        return executor;
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/support/error/ErrorType.java
+++ b/apps/commerce-api/src/main/java/com/loopers/support/error/ErrorType.java
@@ -12,7 +12,8 @@ public enum ErrorType {
     BAD_REQUEST(HttpStatus.BAD_REQUEST, HttpStatus.BAD_REQUEST.getReasonPhrase(), "잘못된 요청입니다."),
     NOT_FOUND(HttpStatus.NOT_FOUND, HttpStatus.NOT_FOUND.getReasonPhrase(), "존재하지 않는 요청입니다."),
     CONFLICT(HttpStatus.CONFLICT, HttpStatus.CONFLICT.getReasonPhrase(), "이미 존재하는 리소스입니다."),
-    PAYMENT_FAILED(HttpStatus.BAD_GATEWAY, HttpStatus.BAD_GATEWAY.getReasonPhrase(), "결제 처리에 실패했습니다.");
+    PAYMENT_FAILED(HttpStatus.BAD_GATEWAY, HttpStatus.BAD_GATEWAY.getReasonPhrase(), "결제 처리에 실패했습니다."),
+    ORDER_CREATION_FAILED(HttpStatus.BAD_GATEWAY, HttpStatus.BAD_GATEWAY.getReasonPhrase(), "주문 생성에 실패했습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/apps/commerce-api/src/test/java/com/loopers/application/brand/BrandApplicationServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/brand/BrandApplicationServiceIntegrationTest.java
@@ -5,6 +5,7 @@ import com.loopers.domain.product.ProductModel;
 import com.loopers.infrastructure.brand.BrandJpaRepository;
 import com.loopers.infrastructure.product.ProductJpaRepository;
 import com.loopers.support.config.TestConfig;
+import com.loopers.testcontainers.MySqlTestContainersConfig;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import com.loopers.utils.DatabaseCleanUp;
@@ -23,7 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SpringBootTest
-@Import(TestConfig.class)
+@Import({TestConfig.class, MySqlTestContainersConfig.class})
 public class BrandApplicationServiceIntegrationTest {
 
     @Autowired

--- a/apps/commerce-api/src/test/java/com/loopers/application/category/CategoryApplicationServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/category/CategoryApplicationServiceIntegrationTest.java
@@ -5,6 +5,7 @@ import com.loopers.domain.product.ProductModel;
 import com.loopers.infrastructure.category.CategoryJpaRepository;
 import com.loopers.infrastructure.product.ProductJpaRepository;
 import com.loopers.support.config.TestConfig;
+import com.loopers.testcontainers.MySqlTestContainersConfig;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import com.loopers.utils.DatabaseCleanUp;
@@ -23,7 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SpringBootTest
-@Import(TestConfig.class)
+@Import({TestConfig.class, MySqlTestContainersConfig.class})
 public class CategoryApplicationServiceIntegrationTest {
 
     @Autowired

--- a/apps/commerce-api/src/test/java/com/loopers/application/like/FakeProductRepository.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/like/FakeProductRepository.java
@@ -109,8 +109,9 @@ public class FakeProductRepository implements ProductRepository {
             ReflectionTestUtils.setField(product, "id", newId);
         }
         
-        // ID가 있으면 업데이트, 없으면 새로 생성
-        return products.put(product.getId(), product);
+        // 상품을 저장하고 저장된 상품을 반환
+        products.put(product.getId(), product);
+        return product;
     }
     
     @Override

--- a/apps/commerce-api/src/test/java/com/loopers/application/like/LikeApplicationServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/like/LikeApplicationServiceIntegrationTest.java
@@ -1,23 +1,31 @@
 package com.loopers.application.like;
 
+import com.loopers.domain.brand.BrandModel;
+import com.loopers.domain.category.CategoryModel;
 import com.loopers.domain.like.LikeRepository;
 import com.loopers.domain.product.ProductModel;
 import com.loopers.domain.user.*;
-import com.loopers.domain.brand.BrandModel;
-import com.loopers.domain.category.CategoryModel;
-import com.loopers.infrastructure.product.ProductJpaRepository;
 import com.loopers.infrastructure.brand.BrandJpaRepository;
 import com.loopers.infrastructure.category.CategoryJpaRepository;
+import com.loopers.infrastructure.product.ProductJpaRepository;
+import com.loopers.support.config.LikeTestConfig;
 import com.loopers.utils.DatabaseCleanUp;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.reset;
+import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 
 @SpringBootTest
+@Import(LikeTestConfig.class)
 class LikeApplicationServiceIntegrationTest {
 
     @Autowired
@@ -47,9 +55,15 @@ class LikeApplicationServiceIntegrationTest {
     private CategoryModel category;
     private UserModel user;
 
+    @Autowired
+    private LikeCountProcessor likeCountProcessor;
+
     @BeforeEach
     void setUp() {
         databaseCleanUp.truncateAllTables();
+        
+        // Mock 호출 기록 초기화
+        reset(likeCountProcessor);
         
         // User 먼저 생성
         userId = UserId.of("seyoung");
@@ -84,22 +98,30 @@ class LikeApplicationServiceIntegrationTest {
         // when - 첫 번째 좋아요 요청
         likeApplicationService.like(userId, productId);
 
-        // then - 첫 번째 요청이 성공적으로 처리됨
-        assertThat(likeApplicationService.isLiked(userId, productId)).isTrue();
-        assertThat(likeRepository.countByProductId(productId)).isEqualTo(1);
-        
-        ProductModel updatedProduct = productJpaRepository.findById(productId).orElseThrow();
-        assertThat(updatedProduct.getLikesCount()).isEqualTo(1);
+        // then - 첫 번째 요청이 성공적으로 처리됨 (이벤트 기반 비동기이므로 eventually 확인)
+        await().atMost(Duration.ofSeconds(2)).untilAsserted(() -> {
+            assertThat(likeApplicationService.isLiked(userId, productId)).isTrue();
+            assertThat(likeRepository.countByProductId(productId)).isEqualTo(1);
+            ProductModel unchangedProduct = productJpaRepository.findById(productId).orElseThrow();
+            assertThat(unchangedProduct.getLikesCount()).isEqualTo(1);
+        });
+
+        // processor 호출 검증 (비동기 호출)
+        verify(likeCountProcessor, timeout(1500)).updateProductLikeCount(productId, 1);
 
         // when - 두 번째 좋아요 요청 (중복)
         likeApplicationService.like(userId, productId);
 
-        // then - 두 번째 요청부터 상태 변화 없음
-        assertThat(likeApplicationService.isLiked(userId, productId)).isTrue();
-        assertThat(likeRepository.countByProductId(productId)).isEqualTo(1);
-        
-        ProductModel unchangedProduct = productJpaRepository.findById(productId).orElseThrow();
-        assertThat(unchangedProduct.getLikesCount()).isEqualTo(1);
+        // then - 두 번째 요청부터 상태 변화 없음 (eventually)
+        await().atMost(Duration.ofSeconds(2)).untilAsserted(() -> {
+            assertThat(likeApplicationService.isLiked(userId, productId)).isTrue();
+            assertThat(likeRepository.countByProductId(productId)).isEqualTo(1);
+            ProductModel unchangedProduct2 = productJpaRepository.findById(productId).orElseThrow();
+            assertThat(unchangedProduct2.getLikesCount()).isEqualTo(1);
+        });
+
+        // 중복 요청 후에도 processor는 추가로 호출되지 않음을 확인 (여전히 1번만)
+        verify(likeCountProcessor, times(1)).updateProductLikeCount(productId, 1);
     }
 
     @Test
@@ -113,22 +135,30 @@ class LikeApplicationServiceIntegrationTest {
         // when - 첫 번째 좋아요 취소 요청
         likeApplicationService.unlike(userId, productId);
 
-        // then - 첫 번째 요청이 성공적으로 처리됨
-        assertThat(likeApplicationService.isLiked(userId, productId)).isFalse();
-        assertThat(likeRepository.countByProductId(productId)).isEqualTo(0);
-        
-        ProductModel updatedProduct = productJpaRepository.findById(productId).orElseThrow();
-        assertThat(updatedProduct.getLikesCount()).isEqualTo(0);
+        // then - 첫 번째 요청이 성공적으로 처리됨 (eventually)
+        await().atMost(Duration.ofSeconds(2)).untilAsserted(() -> {
+            assertThat(likeApplicationService.isLiked(userId, productId)).isFalse();
+            assertThat(likeRepository.countByProductId(productId)).isEqualTo(0);
+            ProductModel updatedProduct = productJpaRepository.findById(productId).orElseThrow();
+            assertThat(updatedProduct.getLikesCount()).isEqualTo(0);
+        });
+
+        // processor 호출 검증
+        verify(likeCountProcessor, timeout(1500)).updateProductLikeCount(productId, -1);
 
         // when - 두 번째 좋아요 취소 요청 (중복)
         likeApplicationService.unlike(userId, productId);
 
-        // then - 두 번째 요청은 무시됨 (상태 변화 없음)
-        assertThat(likeApplicationService.isLiked(userId, productId)).isFalse();
-        assertThat(likeRepository.countByProductId(productId)).isEqualTo(0);
-        
-        ProductModel unchangedProduct = productJpaRepository.findById(productId).orElseThrow();
-        assertThat(unchangedProduct.getLikesCount()).isEqualTo(0);
+        // then - 두 번째 요청은 무시됨 (상태 변화 없음, eventually)
+        await().atMost(Duration.ofSeconds(2)).untilAsserted(() -> {
+            assertThat(likeApplicationService.isLiked(userId, productId)).isFalse();
+            assertThat(likeRepository.countByProductId(productId)).isEqualTo(0);
+            ProductModel unchangedProduct3 = productJpaRepository.findById(productId).orElseThrow();
+            assertThat(unchangedProduct3.getLikesCount()).isEqualTo(0);
+        });
+
+        // 중복 요청 후에도 processor는 추가로 호출되지 않음을 확인 (여전히 1번만)
+        verify(likeCountProcessor, times(1)).updateProductLikeCount(productId, -1);
     }
 
     @Test
@@ -140,31 +170,29 @@ class LikeApplicationServiceIntegrationTest {
         // when - 좋아요 등록
         likeApplicationService.like(userId, productId);
 
-        // then - 좋아요 등록 확인
-        assertThat(likeApplicationService.isLiked(userId, productId)).isTrue();
-        assertThat(likeRepository.countByProductId(productId)).isEqualTo(1);
-        
-        ProductModel likedProduct = productJpaRepository.findById(productId).orElseThrow();
-        assertThat(likedProduct.getLikesCount()).isEqualTo(1);
+        // then - 좋아요 등록 확인 (eventually)
+        await().atMost(Duration.ofSeconds(2)).untilAsserted(() -> {
+            assertThat(likeApplicationService.isLiked(userId, productId)).isTrue();
+            assertThat(likeRepository.countByProductId(productId)).isEqualTo(1);
+        });
 
         // when - 좋아요 취소
         likeApplicationService.unlike(userId, productId);
 
-        // then - 좋아요 취소 확인
-        assertThat(likeApplicationService.isLiked(userId, productId)).isFalse();
-        assertThat(likeRepository.countByProductId(productId)).isEqualTo(0);
+        // then - 좋아요 취소 확인 (eventually)
+        await().atMost(Duration.ofSeconds(2)).untilAsserted(() -> {
+            assertThat(likeApplicationService.isLiked(userId, productId)).isFalse();
+            assertThat(likeRepository.countByProductId(productId)).isEqualTo(0);
+        });
         
-        ProductModel unlikedProduct = productJpaRepository.findById(productId).orElseThrow();
-        assertThat(unlikedProduct.getLikesCount()).isEqualTo(0);
-
         // when - 다시 좋아요 등록
         likeApplicationService.like(userId, productId);
 
-        // then - 다시 좋아요 등록 확인
-        assertThat(likeApplicationService.isLiked(userId, productId)).isTrue();
-        assertThat(likeRepository.countByProductId(productId)).isEqualTo(1);
+        // then - 다시 좋아요 등록 확인 (eventually)
+        await().atMost(Duration.ofSeconds(2)).untilAsserted(() -> {
+            assertThat(likeApplicationService.isLiked(userId, productId)).isTrue();
+            assertThat(likeRepository.countByProductId(productId)).isEqualTo(1);
+        });
         
-        ProductModel relikedProduct = productJpaRepository.findById(productId).orElseThrow();
-        assertThat(relikedProduct.getLikesCount()).isEqualTo(1);
     }
 } 

--- a/apps/commerce-api/src/test/java/com/loopers/application/like/LikeApplicationServiceWithFakeTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/like/LikeApplicationServiceWithFakeTest.java
@@ -2,6 +2,8 @@ package com.loopers.application.like;
 
 import com.loopers.domain.like.LikeModel;
 import com.loopers.domain.like.ProductLikeDomainService;
+import com.loopers.domain.like.event.ProductLikePublisher;
+import com.loopers.domain.like.event.ProductUnLikePublisher;
 import com.loopers.domain.product.ProductModel;
 import com.loopers.domain.user.UserId;
 import com.loopers.support.error.CoreException;
@@ -25,6 +27,12 @@ class LikeApplicationServiceWithFakeTest {
 
     @Mock
     private ProductLikeDomainService productLikeHandler;
+    
+    @Mock
+    private ProductLikePublisher likeEventPublisher;
+    
+    @Mock
+    private ProductUnLikePublisher unlikeEventPublisher;
 
     private LikeApplicationService likeApplicationService;
     private FakeLikeRepository fakeLikeRepository;
@@ -41,9 +49,11 @@ class LikeApplicationServiceWithFakeTest {
         likeApplicationService = new LikeApplicationService(
                 fakeLikeRepository,
                 fakeProductRepository,
-                productLikeHandler, // Mock 주입
-                null, // BrandRepository
-                null  // CategoryRepository
+                productLikeHandler,
+                null,
+                null,
+                likeEventPublisher,
+                unlikeEventPublisher
         );
         
         userId = UserId.of("seyoung");

--- a/apps/commerce-api/src/test/java/com/loopers/application/like/LikeCountEventHandlerTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/like/LikeCountEventHandlerTest.java
@@ -1,0 +1,81 @@
+package com.loopers.application.like;
+
+import com.loopers.domain.like.event.ProductLikedEvent;
+import com.loopers.domain.like.event.ProductUnlikedEvent;
+import com.loopers.domain.user.UserId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+class LikeCountEventHandlerTest {
+
+    @InjectMocks
+    private LikeCountEventHandler likeCountEventHandler;
+
+    private UserId userId;
+    private Long productId;
+
+    @BeforeEach
+    void setUp() {
+        userId = UserId.of("testuser");
+        productId = 1L;
+    }
+
+    @Nested
+    @DisplayName("상품 좋아요 이벤트 처리 시")
+    class Handle_Product_Liked_Event {
+
+        @Test
+        @DisplayName("상품 좋아요 이벤트가 정상적으로 처리된다")
+        void handleProductLikedEvent() {
+            ProductLikedEvent event = ProductLikedEvent.create(productId, userId);
+
+            likeCountEventHandler.handleProductLiked(event);
+        }
+    }
+
+    @Nested
+    @DisplayName("상품 좋아요 취소 이벤트 처리 시")
+    class Handle_Product_Unliked_Event {
+
+        @Test
+        @DisplayName("상품 좋아요 취소 이벤트가 정상적으로 처리된다")
+        void handleProductUnlikedEvent() {
+            ProductUnlikedEvent event = ProductUnlikedEvent.create(productId, userId);
+
+            likeCountEventHandler.handleProductUnliked(event);
+        }
+    }
+
+    @Nested
+    @DisplayName("이벤트 데이터 검증")
+    class Event_Data_Validation {
+
+        @Test
+        @DisplayName("ProductLikedEvent의 데이터가 올바르게 생성된다")
+        void productLikedEventCreation() {
+            ProductLikedEvent event = ProductLikedEvent.create(productId, userId);
+
+            assertThat(event.getProductId()).isEqualTo(productId);
+            assertThat(event.getUserId()).isEqualTo(userId);
+            assertThat(event.getOccurredAt()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("ProductUnlikedEvent의 데이터가 올바르게 생성된다")
+        void productUnlikedEventCreation() {
+            ProductUnlikedEvent event = ProductUnlikedEvent.create(productId, userId);
+
+            assertThat(event.getProductId()).isEqualTo(productId);
+            assertThat(event.getUserId()).isEqualTo(userId);
+            assertThat(event.getOccurredAt()).isNotNull();
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/application/order/CouponUsageOptimisticLockTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/order/CouponUsageOptimisticLockTest.java
@@ -87,9 +87,12 @@ public class CouponUsageOptimisticLockTest {
 
         // when
         for (int i = 1; i <= threadCount; i++) {
+            final long orderId = i;
             executorService.submit(() -> {
                 try {
-                    couponProcessor.useCoupon(user.getUserId(), coupon.getCouponCode());
+                    // 쿠폰을 예약한 다음 사용
+                    couponProcessor.reserveCoupon(user.getUserId(), coupon.getCouponCode(), orderId);
+                    couponProcessor.useCoupon(user.getUserId(), coupon.getCouponCode(), orderId);
                     successCount.incrementAndGet();
                 } catch (Exception e) {
                     failureCount.incrementAndGet();

--- a/apps/commerce-api/src/test/java/com/loopers/application/point/PointApplicationServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/point/PointApplicationServiceIntegrationTest.java
@@ -8,11 +8,14 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import com.loopers.testcontainers.MySqlTestContainersConfig;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SpringBootTest
+@Import(MySqlTestContainersConfig.class)
 public class PointApplicationServiceIntegrationTest {
 
     @Autowired

--- a/apps/commerce-api/src/test/java/com/loopers/application/product/ProductApplicationServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/product/ProductApplicationServiceIntegrationTest.java
@@ -17,6 +17,8 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import com.loopers.testcontainers.MySqlTestContainersConfig;
 
 import java.util.List;
 
@@ -24,6 +26,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SpringBootTest
+@Import(MySqlTestContainersConfig.class)
 public class ProductApplicationServiceIntegrationTest {
 
     @Autowired
@@ -553,7 +556,7 @@ public class ProductApplicationServiceIntegrationTest {
                 ProductModel saved = productJpaRepository.save(product);
 
                 // when
-                ProductOutputInfo productDetail = productApplicationService.getProductDetail(saved.getId());
+                ProductOutputInfo productDetail = productApplicationService.getProductDetail(saved.getId(), null);
 
                 // then
                 assertThat(productDetail).isNotNull();
@@ -565,7 +568,7 @@ public class ProductApplicationServiceIntegrationTest {
             @DisplayName("상품 ID가 존재하지 않을 때 예외를 발생시킨다.")
             void getProductDetailNotFound() {
                 // when & then
-                assertThatThrownBy(() -> productApplicationService.getProductDetail(999L))
+                assertThatThrownBy(() -> productApplicationService.getProductDetail(999L, null))
                         .isInstanceOf(IllegalArgumentException.class);
             }
 
@@ -589,7 +592,7 @@ public class ProductApplicationServiceIntegrationTest {
                 ProductModel savedProduct = productJpaRepository.save(product);
 
                 // when
-                ProductOutputInfo productDetail = productApplicationService.getProductDetail(savedProduct.getId());
+                ProductOutputInfo productDetail = productApplicationService.getProductDetail(savedProduct.getId(), null);
 
                 // then
                 assertThat(productDetail).isNotNull();
@@ -615,7 +618,7 @@ public class ProductApplicationServiceIntegrationTest {
                 System.out.println("After save - Saved Product likesCount: " + savedProduct.getLikesCount()); // Diagnostic
 
                 // when
-                ProductOutputInfo productDetail = productApplicationService.getProductDetail(savedProduct.getId());
+                ProductOutputInfo productDetail = productApplicationService.getProductDetail(savedProduct.getId(), null);
                 System.out.println("After service call - ProductDetail likesCount: " + productDetail.likeCount()); // Diagnostic
 
                 // then

--- a/apps/commerce-api/src/test/java/com/loopers/application/product/UserActingTrackingForProductEventHandlerTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/product/UserActingTrackingForProductEventHandlerTest.java
@@ -1,0 +1,56 @@
+package com.loopers.application.product;
+
+import com.loopers.domain.product.event.ClickContext;
+import com.loopers.domain.product.event.ProductClickedEvent;
+import com.loopers.domain.product.event.ProductViewedEvent;
+import com.loopers.domain.user.UserId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class UserActingTrackingForProductEventHandlerTest {
+
+    @InjectMocks
+    private UserActingTrackingForProductEventHandler userActingTrackingForProductEventHandler;
+
+    private Long productId;
+    private UserId userId;
+
+    @BeforeEach
+    void setUp() {
+        productId = 1L;
+        userId = UserId.of("seyoung");
+    }
+
+    @Nested
+    @DisplayName("상품 조회 이벤트 처리 시")
+    class Handle_Product_Viewed_Event {
+
+        @Test
+        @DisplayName("상품 조회 이벤트가 정상적으로 처리된다")
+        void handleProductViewedEvent() {
+            ProductViewedEvent event = ProductViewedEvent.createDetailView(productId, userId);
+
+            userActingTrackingForProductEventHandler.handleProductViewed(event);
+        }
+    }
+
+    @Nested
+    @DisplayName("상품 클릭 이벤트 처리 시")
+    class Handle_Product_Clicked_Event {
+
+        @Test
+        @DisplayName("상품 클릭 이벤트가 정상적으로 처리된다")
+        void handleProductClickedEvent() {
+            ProductClickedEvent event = ProductClickedEvent.create(productId, userId, ClickContext.SEARCH_RESULT);
+
+            userActingTrackingForProductEventHandler.handleProductClicked(event);
+        }
+    }
+
+}

--- a/apps/commerce-api/src/test/java/com/loopers/application/user/UserApplicationServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/user/UserApplicationServiceIntegrationTest.java
@@ -5,6 +5,7 @@ import com.loopers.domain.user.UserId;
 import com.loopers.domain.user.UserModel;
 import com.loopers.domain.user.UserRepository;
 import com.loopers.support.config.TestConfig;
+import com.loopers.testcontainers.MySqlTestContainersConfig;
 import com.loopers.utils.DatabaseCleanUp;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
@@ -22,7 +23,7 @@ import static org.mockito.Mockito.*;
 
 
 @SpringBootTest
-@Import(TestConfig.class)
+@Import({TestConfig.class, MySqlTestContainersConfig.class})
 class UserApplicationServiceIntegrationTest {
 
     @Autowired

--- a/apps/commerce-api/src/test/java/com/loopers/domain/coupon/CouponValidationDomainServiceTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/coupon/CouponValidationDomainServiceTest.java
@@ -1,7 +1,6 @@
 package com.loopers.domain.coupon;
 
 import com.loopers.domain.user.UserId;
-import com.loopers.support.error.CoreException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -42,7 +41,6 @@ class CouponValidationDomainServiceTest {
         UserCouponModel userCoupon = UserCouponModel.create(UserId.of("seyoung"), "COUPON123");
 
         // when & then
-        // 예외가 발생하지 않으면 성공
         couponValidationDomainService.validateCouponUsage(userCoupon, coupon, 15000, today);
     }
 
@@ -103,7 +101,8 @@ class CouponValidationDomainServiceTest {
                 .build();
 
         UserCouponModel userCoupon = UserCouponModel.create(UserId.of("seyoung"), "COUPON123");
-        userCoupon.useCoupon(today); // 이미 사용된 쿠폰
+        userCoupon.reserve(1L); // 먼저 예약
+        userCoupon.useCoupon(today, 1L); // 이미 사용된 쿠폰
 
         // when & then
         assertThatThrownBy(() -> couponValidationDomainService.validateCouponUsage(userCoupon, coupon, 15000, today))

--- a/apps/commerce-api/src/test/java/com/loopers/domain/coupon/UserCouponDomainTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/coupon/UserCouponDomainTest.java
@@ -59,7 +59,8 @@ class UserCouponDomainTest {
         UserCouponModel userCoupon = UserCouponModel.create(UserId.of("seyoung"), "COUPON123");
 
         // when
-        boolean result = userCoupon.useCoupon(today);
+        userCoupon.reserve(1L);
+        boolean result = userCoupon.useCoupon(today, 1L);
 
         // then
         assertThat(result).isTrue();
@@ -72,10 +73,11 @@ class UserCouponDomainTest {
     void useCoupon_AlreadyUsedCoupon_ThrowsException() {
         // given
         UserCouponModel userCoupon = UserCouponModel.create(UserId.of("seyoung"), "COUPON123");
-        userCoupon.useCoupon(today); // 첫 번째 사용
+        userCoupon.reserve(1L);
+        userCoupon.useCoupon(today, 1L); // 첫 번째 사용
 
         // when & then
-        assertThatThrownBy(() -> userCoupon.useCoupon(tomorrow))
+        assertThatThrownBy(() -> userCoupon.useCoupon(tomorrow, 2L))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
@@ -94,7 +96,8 @@ class UserCouponDomainTest {
     void isUsed_UsedCoupon_ReturnsTrue() {
         // given
         UserCouponModel userCoupon = UserCouponModel.create(UserId.of("seyoung"), "COUPON123");
-        userCoupon.useCoupon(today);
+        userCoupon.reserve(1L);
+        userCoupon.useCoupon(today, 1L);
 
         // when & then
         assertThat(userCoupon.getStatus()).isEqualTo(UserCoupontStatus.USED);
@@ -115,7 +118,8 @@ class UserCouponDomainTest {
     void getUsedAt_UsedCoupon_ReturnsUsedDate() {
         // given
         UserCouponModel userCoupon = UserCouponModel.create(UserId.of("seyoung"), "COUPON123");
-        userCoupon.useCoupon(today);
+        userCoupon.reserve(1L);
+        userCoupon.useCoupon(today, 1L);
 
         // when & then
         assertThat(userCoupon.getUsedAt()).isEqualTo(today);
@@ -151,8 +155,10 @@ class UserCouponDomainTest {
         UserCouponModel userCoupon2 = UserCouponModel.create(UserId.of("seyoung"), "COUPON456");
 
         // when
-        boolean result1 = userCoupon1.useCoupon(today);
-        boolean result2 = userCoupon2.useCoupon(tomorrow);
+        userCoupon1.reserve(1L);
+        boolean result1 = userCoupon1.useCoupon(today, 1L);
+        userCoupon2.reserve(2L);
+        boolean result2 = userCoupon2.useCoupon(tomorrow, 2L);
 
         // then
         assertThat(result1).isTrue();
@@ -170,7 +176,8 @@ class UserCouponDomainTest {
         UserCouponModel userCoupon = UserCouponModel.create(UserId.of("seyoung"), "COUPON123");
 
         // when
-        boolean result = userCoupon.useCoupon(tomorrow);
+        userCoupon.reserve(1L);
+        boolean result = userCoupon.useCoupon(tomorrow, 1L);
 
         // then
         assertThat(result).isTrue();

--- a/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductLikeDomainServiceTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductLikeDomainServiceTest.java
@@ -58,7 +58,6 @@ class ProductLikeDomainServiceTest {
             assertThat(result).isNotNull();
             assertThat(result.getUserId()).isEqualTo(userId);
             assertThat(result.getProductId()).isEqualTo(productId);
-            verify(product).incrementLikesCount();
             verify(likeRepository).existsByUserIdAndProductId(userId, productId);
         }
 
@@ -100,7 +99,6 @@ class ProductLikeDomainServiceTest {
             assertThat(result).isNotNull();
             assertThat(result.getUserId()).isEqualTo(userId);
             assertThat(result.getProductId()).isEqualTo(productId);
-            verify(product).decrementLikesCount();
             verify(likeRepository).existsByUserIdAndProductId(userId, productId);
             verify(likeRepository).findByUserIdAndProductId(userId, productId);
         }

--- a/apps/commerce-api/src/test/java/com/loopers/support/config/LikeTestConfig.java
+++ b/apps/commerce-api/src/test/java/com/loopers/support/config/LikeTestConfig.java
@@ -1,0 +1,22 @@
+package com.loopers.support.config;
+
+import com.loopers.application.like.LikeCountProcessor;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.test.util.AopTestUtils;
+
+import static org.mockito.Mockito.spy;
+
+@TestConfiguration
+public class LikeTestConfig {
+
+    @Bean
+    @Primary
+    public LikeCountProcessor likeCountProcessorSpy(LikeCountProcessor realLikeCountProcessor) {
+        LikeCountProcessor target = AopTestUtils.getTargetObject(realLikeCountProcessor);
+        return spy(target);
+    }
+}
+
+

--- a/apps/commerce-api/src/test/java/com/loopers/support/config/TestConfig.java
+++ b/apps/commerce-api/src/test/java/com/loopers/support/config/TestConfig.java
@@ -1,10 +1,14 @@
 package com.loopers.support.config;
 
 
+import com.loopers.application.like.LikeCountEventHandler;
+import com.loopers.application.product.UserActingTrackingForProductEventHandler;
 import com.loopers.domain.user.UserRepository;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
 
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 
 @TestConfiguration
@@ -15,5 +19,16 @@ public class TestConfig {
         return spy(realUserRepository);
     }
 
+    @Bean
+    @Primary
+    public LikeCountEventHandler mockLikeEventHandler() {
+        return mock(LikeCountEventHandler.class);
+    }
+
+    @Bean
+    @Primary
+    public UserActingTrackingForProductEventHandler mockProductEventHandler() {
+        return mock(UserActingTrackingForProductEventHandler.class);
+    }
 
 }

--- a/apps/commerce-api/src/test/java/com/loopers/support/config/TestEventConfig.java
+++ b/apps/commerce-api/src/test/java/com/loopers/support/config/TestEventConfig.java
@@ -1,0 +1,26 @@
+package com.loopers.support.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+import java.util.concurrent.Executor;
+
+@TestConfiguration
+@EnableAsync
+public class TestEventConfig implements AsyncConfigurer {
+
+    @Bean
+    @Primary
+    @Override
+    public Executor getAsyncExecutor() {
+        return new Executor() {
+            @Override
+            public void execute(Runnable command) {
+                command.run();
+            }
+        };
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -69,6 +69,7 @@ subprojects {
         testImplementation("org.springframework.boot:spring-boot-testcontainers")
         testImplementation("org.testcontainers:testcontainers")
         testImplementation("org.testcontainers:junit-jupiter")
+        testImplementation("org.testcontainers:mysql")
     }
 
     tasks.withType(Jar::class) { enabled = true }

--- a/http/pg-simulator/payments.http
+++ b/http/pg-simulator/payments.http
@@ -1,6 +1,6 @@
 ### 결제 요청
 POST http://localhost:8082/api/v1/payments
-X-USER-ID: 135135
+X-USER-ID: user000001
 Content-Type: application/json
 
 {
@@ -12,7 +12,7 @@ Content-Type: application/json
 }
 
 ### 결제 정보 확인
-GET http://localhost:8082/api/v1/payments/20250819:TR:a03925
+GET http://localhost:8082/api/v1/payments/20250822:TR:1e0bc4
 X-USER-ID: 135135
 
 ### 주문에 엮인 결제 정보 조회


### PR DESCRIPTION
## 📌 Summary

### 변경 사항
- 쿠폰 설계 [apps/commerce-api/src/main/java/com/loopers/domain/coupon/UserCouponModel.java](https://github.com/maiorem/e-commerce/pull/40/files#diff-10e442da1a18f52b87bdb9163189e1d13301c34a698ae4c59b125cb999c8b269)
    - 기존 -> 주문(OrderModel)이 쿠폰코드(String couponCode) 컬럼을 가지고 있고 주문생성 로직에서 이 정보로 쿠폰 예약
    - 변경 -> 쿠폰 예약/사용/복구를 이벤트 기반으로 처리하면서 주문과 쿠폰 분리. UserCoupon이 대신 ref_order_id를 예약시부터 지님. (취소 시 0으로 초기화)
- 주문생성에서 재고차감, 쿠폰예약을 커맨드 발행으로 분리. 
    - [apps/commerce-api/src/main/java/com/loopers/domain/order/event/OrderCeatedCouponReserveCommand.java](https://github.com/maiorem/e-commerce/pull/40/files#diff-945dfbce1ac06fc785216b3454d5f2facf1fca579d97d5affba4da5d294eacfe)
    - [‎apps/commerce-api/src/main/java/com/loopers/domain/order/event/OrderCreatedStockDeductionCommand.java](https://github.com/maiorem/e-commerce/pull/40/files#diff-c10a11dc01a4b37e72a8828a3d85aac9cc26518d82b4d699b86d14574a5f0e73) 
    - [‎apps/commerce-api/src/main/java/com/loopers/application/order/OrderApplicationService.java](https://github.com/maiorem/e-commerce/pull/40/files#diff-43be88664ee2f23ce90751a87bee08a279d18e2973dbdec7eb8b1335fe923e2b)
- 카드결제 시 콜백 후 결제 성공, 결제 실패를 이벤트 처리 [‎apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentApplicationService.java](https://github.com/maiorem/e-commerce/pull/40/files#diff-863ef13650bc6537e62631db68fc084ac0514b5ca09c9f4cf33b97e44f562388)
- 포인트결제 시 즉시 동기적으로 결제 성공, 결제 실패 이벤트 처리  [‎apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentApplicationService.java](https://github.com/maiorem/e-commerce/pull/40/files#diff-863ef13650bc6537e62631db68fc084ac0514b5ca09c9f4cf33b97e44f562388)
- 상품 좋아요 등록/취소 시 상품에서 좋아요 count 집계 이벤트 처리 [‎apps/commerce-api/src/main/java/com/loopers/application/like/LikeApplicationService.java](https://github.com/maiorem/e-commerce/pull/40/files#diff-63a53ef9e1086ad80737c2a7bde860ac8927795fa782875f950dab628972c297)
- 상품 상세정보 view, 좋아요 등록/취소, 주문, 결제처리에 사용자 행위 트래킹 로그 처리 
    - [‎apps/commerce-api/src/main/java/com/loopers/application/like/UserLikeActionTrackingEventHandler.java](https://github.com/maiorem/e-commerce/pull/40/files#diff-4814c62b2064622c6e73fc90fd86d99115acf72bfd5f01f4494bb1d715b3cf3b)
    - [‎apps/commerce-api/src/main/java/com/loopers/application/product/UserActingTrackingForProductEventHandler.java](https://github.com/maiorem/e-commerce/pull/40/files#diff-47b247591137080119b1cb473bcd9d16d9f2adf1fbd00b6c3fbb23ea2a0c80a0)
    - [‎apps/commerce-api/src/main/java/com/loopers/application/order/OrderEventHandler.java](https://github.com/maiorem/e-commerce/pull/40/files#diff-1aae725658fa698c233c46a93fd4a50e15e620bc01bb1b2877dcd34f428df2b2)
    - [‎apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentSuccessEventHandler.java](https://github.com/maiorem/e-commerce/pull/40/files#diff-a7feaefcad10731d84fa2e501aee283986f36bf0d82c66ebbd4524c812adbc26)
    - [‎apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentSuccessEventHandler.java](https://github.com/maiorem/e-commerce/pull/40/files#diff-a7feaefcad10731d84fa2e501aee283986f36bf0d82c66ebbd4524c812adbc26) 
- 상품 클릭 이벤트는 프론트엔드에서 처리하도록 컨트롤러 생성 [‎apps/commerce-api/src/main/java/com/loopers/interfaces/api/event/EventV1Controller.java](https://github.com/maiorem/e-commerce/pull/40/files#diff-9928ce546f683aa31ef2c969d0b8b808efe284766cb5afea5f13166e4eebaa75)
- 관련 테스트를 비동기 기반으로 수정


## 💬 Review Points

## 주문생성에서 분리한 기능들

### 1. 결제요청 동기처리에 대해
- 결제요청은 처음에는 주문생성에서 Sync 커맨드 발행으로 처리하다 다시 Api에서 OrderApplicationService 주문생성 흐름 후에 PaymentApplicationService의 카드결제/포인트결제 흐름을 타도록 복구했습니다. 유연한 설계와 데이터 정합성 사이에서 고민이 많았지만 주문생성에서 결제요청으로 가는 흐름은 결합도를 낮추는 것보다 데이터 정합성이 더 큰 우선순위라 판단했기 때문입니다. 관련해서 실제로는 어떻게 처리되는지 궁금합니다.

### 2. 쿠폰예약/재고차감 커맨드 발행          
- 쿠폰생성, 재고차감은 주문생성에서 기록을 위해 발행하는 이벤트와는 별도의 뚜렷한 목적을 지닌 커맨드로 발행하였습니다. 부가기능보다는 주요도가 높다고 판단되어 Sync+BeforeCommit을 활용하여 주문 생성 트랜잭션의 일부로서 처리되도록 구현했습니다.
- 데이터 플랫폼 전송, 사용자 행위 트래킹은 필수적이지 않은 부가기능으로 실패 여부와 관계 없이 발행하는 주로직이 성공해야 합니다. 때문에 비동기 + AfterCommit으로 처리하였습니다.
- 결제실패 후 쿠폰/재고복구의 경우에는 어차피 콜백 후에 이벤트로 발행할 수 있는 정보가 한정적이므로 별도의 이벤트로 분리하지 않고 데이터 플랫폼/사용자 트래킹과 동일한 이벤트로 publish 후 Sync + BeforeCommit으로 처리하였습니다.
- 쿠폰으로 할인된 가격을 분리하지 않은 것이 신경쓰이기는 하는데, 이미 주문생성에서 발행되는 이벤트 기반 처리가 셋이라 복잡도가 높아질 것을 우려하여 놔 둔 상태입니다. 물론 쿠폰 예약이 실패한 경우 주문생성도 실패하므로 쿠폰 할인 가격은 적용되었는데 쿠폰 예약은 실패하는 경우는 없겠지만, 이러면 분리의 의미가 약해질 것 같은데 할인가격을 어떻게 이벤츄얼하게 적용할지 전략을 세우지 못한 상태입니다. 결합도를 낮추기 위해 이벤트 발행 복잡도를 높이는 것 사이에서 고민이 큰데 멘토님이라면 어떻게 가격을 처리하실지 궁금합니다.

## 주문에서 쿠폰 분리하기
- 원래 OrderModel에 String couponCode 필드가 존재했고 이 정보를 이용하여 주문생성 내에서 쿠폰 예약을 처리하였습니다. 그러나 주문이 쿠폰의 동작을 굳이 알 필요가 없다는 판단에 이벤트를 활용해 로직을 분리하였고 OrderModel에서도 쿠폰코드를 들어내게 되었습니다. 주문생성 이벤트 당시에는 쿠폰예약 이벤트를 발행하는 주체인 주문생성 메서드가 쿠폰코드를 알고 있었기에 쿠폰예약 커맨드를 발행하는 것이 문제가 되지 않았으나 카드 결제 후 콜백을 받은 후에 결제가 완료 혹은 실패 한 후 쿠폰을 복구하는 과정에서 문제가 발생하였습니다. 주문이 쿠폰에 대해 알지 못해 쿠폰 정보를 어디에서도 받아올 수가 없게 되었습니다.
- 이에 대한 해결책으로 사용자가 지니고 있던 UserCouponModel에 레퍼런스 orderId 필드를 추가하였습니다. 유저에게 쿠폰을 지급하는 당시에는 orderId를 0으로 주입하고 쿠폰예약시부터 주문의 orderId를 필드에 주입하였고 이를 결제 완료, 실패시에도 사용했습니다. 
- 주문이 쿠폰 정보를 지니고 있는것과 사용자쿠폰이 주문정보를 지니고 있는 것이 크게 다르지 않은 것 같으면서도 사용자가 지금 어떤 주문에 활용한 쿠폰이 어디에 활용되었는지에 대한 정보를 지니고 있는 쪽이, 주문이 쿠폰 정보를 가지고 있는 것 보다 합리적이라 생각했는데 혹시 어떻게 생각하시는지 궁금합니다. 실무에서는 쿠폰을 다른 도메인과 분리할 때 콜백 등과 같이 격리된 API에서 어떻게 정보를 불러내어 활용하나요?
- 현재 UserCouponModel은 이렇게 재설계 되었습니다. (예약 시점에 orderId를 주입, 취소 시 0 으로 초기화)

<img width="339" height="339" alt="image" src="https://github.com/user-attachments/assets/56687e1d-af34-43e0-aff4-35acf874d74e" />

           
```
// 예약 시 orderId 세팅 (디폴트 값은 0L)
public void reserve(Long orderId) {
    if (this.status != UserCoupontStatus.AVAILABLE) {
        throw new IllegalStateException("사용할 수 없는 쿠폰입니다.");
    }
    this.status = UserCoupontStatus.RESERVED;
    this.orderId = orderId;
}

// 취소 시 0L로 초기화  
public void cancelReservation() {
    if (this.status != UserCoupontStatus.RESERVED) {
        throw new IllegalStateException("예약 취소할 수 없는 쿠폰입니다.");
    }
    this.status = UserCoupontStatus.AVAILABLE;
    this.orderId = 0L;
}
```


## ✅ Checklist
### 🧾 주문 ↔ 결제

- [x]  **이벤트 기반**으로 주문 트랜잭션과 쿠폰 사용 처리를 분리한다.
- [x]  **이벤트 기반**으로 결제 결과에 따른 주문 처리를 분리한다.
- [x]  **이벤트 기반**으로 주문, 결제의 결과에 대한 데이터 플랫폼에 전송하는 후속처리를 진행한다.

### ❤️ 좋아요 ↔ 집계

- [x]  **이벤트 기반**으로 좋아요 처리와 집계를 분리한다.
- [x]  집계 로직의 성공/실패와 상관 없이, 좋아요 처리는 정상적으로 완료되어야 한다.

### 📽️ 공통

- [x]  이벤트 기반으로 `유저의 행동` 에 대해 서버 레벨에서 로깅하고, 추적할 방법을 고민해 봅니다.
    
    > *상품 조회, 클릭, 좋아요, 주문 등*
    > 
- [x]  동작의 주체를 적절하게 분리하고, 트랜잭션 간의 연관관계를 고민해 봅니다.

## 📎 References
<!--
  (Optional: 참고 자료가 없는 작업 - 단순 버그 픽스 등 의 경우엔 해당 란을 제거해주세요 !)
  리뷰어가 참고할 수 있는 추가적인 정보나 문서, 링크 등을 작성해주세요.
  예시:
  - 관련 문서 링크
  - 관련 정책 링크
-->