### PR TITLE
[round-9] 랭킹 시스템

### DIFF
--- a/apps/commerce-api/src/main/java/com/loopers/application/like/LikeCountProcessor.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/like/LikeCountProcessor.java
@@ -4,7 +4,7 @@ import com.loopers.domain.like.event.LikeChangePublisher;
 import com.loopers.domain.product.ProductModel;
 import com.loopers.domain.product.ProductRepository;
 import com.loopers.domain.user.UserId;
-import com.loopers.event.LikeChangedEvent;
+import com.loopers.domain.like.event.LikeChangedEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderApplicationService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderApplicationService.java
@@ -6,7 +6,7 @@ import com.loopers.domain.order.OrderItemModel;
 import com.loopers.domain.order.OrderModel;
 import com.loopers.domain.order.event.*;
 import com.loopers.domain.product.ProductModel;
-import com.loopers.event.OrderCreatedEvent;
+import com.loopers.domain.order.event.OrderCreatedEvent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderApplicationService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderApplicationService.java
@@ -51,12 +51,23 @@ public class OrderApplicationService {
 		// 5. 주문 아이템 저장
 		List<OrderItemModel> savedOrderItems = orderPersistenceHandler.saveOrderItem(savedOrder, orderItems);
 
-		// -- 주문생성 이벤트 발행 --
-        orderCreatedPublisher.publish(OrderCreatedEvent.from(savedOrder.getId(), savedOrder.getOrderNumber().getValue(), savedOrder.getUserId().getValue(), savedOrder.getTotalAmount().getAmount(), savedOrder.getOrderDate().getValue()));
-        // -- 쿠폰예약 커맨드 발행 --
-        couponReservePublisher.publish(OrderCeatedCouponReserveCommand.create(savedOrder.getId(), savedOrder.getUserId(), command.couponCode()));
-        // -- 재고차감 커맨드 발행 --
-        stockDeductionPublisher.publish(OrderCreatedStockDeductionCommand.create(orderItems));
+		// 6. 이벤트 및 커맨드 발행
+		// 주문 생성 이벤트 발행
+		orderCreatedPublisher.publish(OrderCreatedEvent.from(
+			savedOrder.getId(),
+			savedOrder.getOrderNumber().getValue(),
+			savedOrder.getUserId().getValue(),
+			savedOrder.getTotalAmount().getAmount(),
+			savedOrder.getOrderDate().getValue(),
+			savedOrderItems,
+			products
+		));
+		
+		// 쿠폰 예약 커맨드 발행
+		couponReservePublisher.publish(OrderCeatedCouponReserveCommand.create(savedOrder.getId(), savedOrder.getUserId(), command.couponCode()));
+		
+		// 재고 차감 커맨드 발행
+		stockDeductionPublisher.publish(OrderCreatedStockDeductionCommand.create(orderItems));
 
 		return OrderInfo.from(savedOrder, OrderItemInfo.createOrderItemInfos(savedOrderItems, products));
 	}

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderEventHandler.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderEventHandler.java
@@ -10,7 +10,7 @@ import com.loopers.domain.user.UserId;
 import com.loopers.domain.user.event.UserActionData;
 import com.loopers.domain.user.event.UserActionTrackingPort;
 import com.loopers.domain.user.event.UserActionType;
-import com.loopers.event.OrderCreatedEvent;
+import com.loopers.domain.order.event.OrderCreatedEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/ProductApplicationService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/ProductApplicationService.java
@@ -9,7 +9,7 @@ import com.loopers.domain.product.ProductRepository;
 import com.loopers.domain.product.ProductSearchDomainService;
 import com.loopers.domain.product.ProductSortBy;
 import com.loopers.domain.product.event.ProductDetailViewedPublisher;
-import com.loopers.event.ProductViewedEvent;
+import com.loopers.domain.product.event.ProductViewedEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/StockDeductionProcessor.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/StockDeductionProcessor.java
@@ -4,7 +4,7 @@ import com.loopers.domain.order.OrderItemModel;
 import com.loopers.domain.product.ProductModel;
 import com.loopers.domain.product.ProductRepository;
 import com.loopers.domain.product.ProductStockDomainService;
-import com.loopers.event.StockAdjustedEvent;
+import com.loopers.domain.product.event.StockAdjustedEvent;
 import com.loopers.domain.product.event.StockAdjustedPublisher;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/UserActingTrackingForProductEventHandler.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/UserActingTrackingForProductEventHandler.java
@@ -6,7 +6,7 @@ import com.loopers.domain.user.UserId;
 import com.loopers.domain.user.event.UserActionData;
 import com.loopers.domain.user.event.UserActionTrackingPort;
 import com.loopers.domain.user.event.UserActionType;
-import com.loopers.event.ProductViewedEvent;
+import com.loopers.domain.product.event.ProductViewedEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;

--- a/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingApplicationService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingApplicationService.java
@@ -1,6 +1,6 @@
 package com.loopers.application.ranking;
 
-import com.loopers.domain.ranking.RankingService;
+import com.loopers.domain.ranking.RankingCacheProcessor;
 import com.loopers.domain.ranking.RankingPage;
 import com.loopers.domain.ranking.RankingQueryRepository;
 import lombok.RequiredArgsConstructor;
@@ -15,7 +15,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class RankingApplicationService {
 
-    private final RankingService rankingService;
+    private final RankingCacheProcessor rankingCacheProcessor;
     private final RankingQueryRepository rankingQueryRepository;
 
     public RankingPageInfo getRankingPage(LocalDate date, int page, int size) {
@@ -56,8 +56,8 @@ public class RankingApplicationService {
     }
 
     public RankingInfo getProductRankingInfo(Long productId, LocalDate date) {
-        Long rank = rankingService.getProductRank(productId, date);
-        Double score = rankingService.getProductScore(productId, date);
+        Long rank = rankingCacheProcessor.getProductRank(productId, date);
+        Double score = rankingCacheProcessor.getProductScore(productId, date);
         
         return RankingInfo.builder()
                 .productId(productId)

--- a/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingApplicationService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingApplicationService.java
@@ -1,0 +1,69 @@
+package com.loopers.application.ranking;
+
+import com.loopers.domain.ranking.RankingService;
+import com.loopers.domain.ranking.RankingPage;
+import com.loopers.domain.ranking.RankingQueryRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RankingApplicationService {
+
+    private final RankingService rankingService;
+    private final RankingQueryRepository rankingQueryRepository;
+
+    public RankingPageInfo getRankingPage(LocalDate date, int page, int size) {
+        log.debug("랭킹 페이지 조회 - Date: {}, Page: {}, Size: {}", date, page, size);
+        
+        RankingPage domainRankingPage = rankingQueryRepository.getRankingWithProducts(date, page, size);
+        
+        List<RankingItemInfo> applicationItems = domainRankingPage.getItems().stream()
+                .map(domainItem -> {
+                    RankingItemInfo.RankingItemInfoBuilder builder = RankingItemInfo.builder()
+                            .productId(domainItem.getProductId())
+                            .rank(domainItem.getRank())
+                            .score(domainItem.getScore());
+                    
+                    if (domainItem.getProductInfo() != null) {
+                        RankingItemInfo.ProductInfo applicationProductInfo = RankingItemInfo.ProductInfo.builder()
+                                .name(domainItem.getProductInfo().getName())
+                                .description(domainItem.getProductInfo().getDescription())
+                                .price(domainItem.getProductInfo().getPrice())
+                                .brandName(domainItem.getProductInfo().getBrandName())
+                                .likeCount(domainItem.getProductInfo().getLikeCount())
+                                .build();
+                        
+                        return builder.build().withProductInfo(applicationProductInfo);
+                    }
+                    
+                    return builder.build();
+                })
+                .toList();
+        
+        return RankingPageInfo.builder()
+                .items(applicationItems)
+                .page(domainRankingPage.getCurrentPage())
+                .size(domainRankingPage.getPageSize())
+                .totalItems(domainRankingPage.getTotalCount().intValue())
+                .date(date)
+                .build();
+    }
+
+    public RankingInfo getProductRankingInfo(Long productId, LocalDate date) {
+        Long rank = rankingService.getProductRank(productId, date);
+        Double score = rankingService.getProductScore(productId, date);
+        
+        return RankingInfo.builder()
+                .productId(productId)
+                .date(date)
+                .rank(rank)
+                .score(score)
+                .build();
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingInfo.java
@@ -1,0 +1,15 @@
+package com.loopers.application.ranking;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+public class RankingInfo {
+    private final Long productId;
+    private final LocalDate date;
+    private final Long rank;
+    private final Double score;
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingItemInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingItemInfo.java
@@ -1,0 +1,29 @@
+package com.loopers.application.ranking;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class RankingItemInfo {
+    private final Long productId;
+    private final Long rank;
+    private final Double score;
+    
+    private ProductInfo productInfo;
+    
+    @Getter
+    @Builder
+    public static class ProductInfo {
+        private final String name;
+        private final String description;
+        private final int price;
+        private final String brandName;
+        private final long likeCount;
+    }
+    
+    public RankingItemInfo withProductInfo(ProductInfo productInfo) {
+        this.productInfo = productInfo;
+        return this;
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingPageInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingPageInfo.java
@@ -1,0 +1,17 @@
+package com.loopers.application.ranking;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@Builder
+public class RankingPageInfo {
+    private final LocalDate date;
+    private final int page;
+    private final int size;
+    private final int totalItems;
+    private final List<RankingItemInfo> items;
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/external/DataPlatformPort.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/external/DataPlatformPort.java
@@ -2,7 +2,7 @@ package com.loopers.domain.external;
 
 import com.loopers.domain.payment.event.PaymentFailedEvent;
 import com.loopers.domain.payment.event.PaymentSuccessEvent;
-import com.loopers.event.OrderCreatedEvent;
+import com.loopers.domain.order.event.OrderCreatedEvent;
 
 public interface DataPlatformPort {
 

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/event/LikeChangePublisher.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/event/LikeChangePublisher.java
@@ -1,7 +1,5 @@
 package com.loopers.domain.like.event;
 
-import com.loopers.event.LikeChangedEvent;
-
 public interface LikeChangePublisher {
     void publish(LikeChangedEvent event);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/event/LikeChangeType.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/event/LikeChangeType.java
@@ -1,4 +1,4 @@
-package com.loopers.event;
+package com.loopers.domain.like.event;
 
 public enum LikeChangeType {
     LIKE, UNLIKE

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/event/LikeChangedEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/event/LikeChangedEvent.java
@@ -1,4 +1,4 @@
-package com.loopers.event;
+package com.loopers.domain.like.event;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/event/OrderCreatedEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/event/OrderCreatedEvent.java
@@ -1,4 +1,4 @@
-package com.loopers.event;
+package com.loopers.domain.order.event;
 
 
 import lombok.Getter;

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/event/OrderCreatedPublisher.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/event/OrderCreatedPublisher.java
@@ -1,7 +1,5 @@
 package com.loopers.domain.order.event;
 
-import com.loopers.event.OrderCreatedEvent;
-
 public interface OrderCreatedPublisher {
     void  publish(OrderCreatedEvent event);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/event/ProductChangedPublisher.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/event/ProductChangedPublisher.java
@@ -1,7 +1,5 @@
 package com.loopers.domain.product.event;
 
-import com.loopers.event.ProductViewedEvent;
-
 public interface ProductChangedPublisher {
     void publishEvent(ProductViewedEvent event);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/event/ProductDetailViewedPublisher.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/event/ProductDetailViewedPublisher.java
@@ -1,7 +1,5 @@
 package com.loopers.domain.product.event;
 
-import com.loopers.event.ProductViewedEvent;
-
 public interface ProductDetailViewedPublisher {
     void publish(ProductViewedEvent event);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/event/ProductViewedEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/event/ProductViewedEvent.java
@@ -1,4 +1,4 @@
-package com.loopers.event;
+package com.loopers.domain.product.event;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/event/StockAdjustedEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/event/StockAdjustedEvent.java
@@ -1,4 +1,4 @@
-package com.loopers.event;
+package com.loopers.domain.product.event;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/event/StockAdjustedPublisher.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/event/StockAdjustedPublisher.java
@@ -1,7 +1,5 @@
 package com.loopers.domain.product.event;
 
-import com.loopers.event.StockAdjustedEvent;
-
 public interface StockAdjustedPublisher {
     void publish(StockAdjustedEvent event);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingApiCacheRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingApiCacheRepository.java
@@ -1,0 +1,10 @@
+package com.loopers.domain.ranking;
+
+import java.util.Set;
+
+public interface RankingApiCacheRepository {
+    Set<Object> getReversedRank(String key, long start, long end);
+    Long getProductRank(String key, Long productId);
+    Double getProductScore(String key, Long productId);
+    Long getTotalRankingCount(String key);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingCacheProcessor.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingCacheProcessor.java
@@ -2,7 +2,6 @@ package com.loopers.domain.ranking;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
@@ -12,9 +11,9 @@ import java.util.Set;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class RankingService {
+public class RankingCacheProcessor {
 
-    private final RedisTemplate<String, Object> redisTemplate;
+    private final RankingApiCacheRepository cacheRepository;
     
     private static final String RANKING_KEY_PREFIX = "ranking:all:";
     private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
@@ -23,34 +22,30 @@ public class RankingService {
         return RANKING_KEY_PREFIX + date.format(DATE_FORMATTER);
     }
 
-    public String generateDailyKey() {
-        return generateDailyKey(LocalDate.now());
-    }
-
     public Set<Object> getRankingByPage(LocalDate date, int page, int size) {
         String key = generateDailyKey(date);
         int start = (page - 1) * size;
         int end = start + size - 1;
         
         // 내림차순 정렬 (높은 점수부터)
-        return redisTemplate.opsForZSet().reverseRange(key, start, end);
+        return cacheRepository.getReversedRank(key, start, end);
     }
 
     public Long getProductRank(Long productId, LocalDate date) {
         String key = generateDailyKey(date);
 
-        // reverseRank (높은 점수부터 0번째 순위)
-        Long rank = redisTemplate.opsForZSet().reverseRank(key, productId.toString());
+        // 높은 점수부터 0번째 순위
+        Long rank = cacheRepository.getProductRank(key, productId);
         return rank != null ? rank + 1 : null; // 1부터 시작하는 순위로 변환
     }
 
     public Double getProductScore(Long productId, LocalDate date) {
         String key = generateDailyKey(date);
-        return redisTemplate.opsForZSet().score(key, productId.toString());
+        return cacheRepository.getProductScore(key, productId);
     }
 
     public Long getTotalRankingCount(LocalDate date) {
         String key = generateDailyKey(date);
-        return redisTemplate.opsForZSet().count(key, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY);
+        return cacheRepository.getTotalRankingCount(key);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingItem.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingItem.java
@@ -1,0 +1,23 @@
+package com.loopers.domain.ranking;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class RankingItem {
+    private final Long productId;
+    private final Long rank;
+    private final Double score;
+    private final ProductInfo productInfo;
+    
+    @Getter
+    @Builder
+    public static class ProductInfo {
+        private final String name;
+        private final String description;
+        private final int price;
+        private final String brandName;
+        private final long likeCount;
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingPage.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingPage.java
@@ -1,0 +1,28 @@
+package com.loopers.domain.ranking;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class RankingPage {
+    private final List<RankingItem> items;
+    private final int currentPage;
+    private final int pageSize;
+    private final Long totalCount;
+    private final int totalPages;
+    private final boolean hasNext;
+    
+    public static RankingPage empty(int page, int size) {
+        return RankingPage.builder()
+                .items(List.of())
+                .currentPage(page)
+                .pageSize(size)
+                .totalCount(0L)
+                .totalPages(0)
+                .hasNext(false)
+                .build();
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingQueryRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingQueryRepository.java
@@ -1,0 +1,7 @@
+package com.loopers.domain.ranking;
+
+import java.time.LocalDate;
+
+public interface RankingQueryRepository {
+    RankingPage getRankingWithProducts(LocalDate date, int page, int size);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingService.java
@@ -1,0 +1,56 @@
+package com.loopers.domain.ranking;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Set;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RankingService {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    
+    private static final String RANKING_KEY_PREFIX = "ranking:all:";
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+    public String generateDailyKey(LocalDate date) {
+        return RANKING_KEY_PREFIX + date.format(DATE_FORMATTER);
+    }
+
+    public String generateDailyKey() {
+        return generateDailyKey(LocalDate.now());
+    }
+
+    public Set<Object> getRankingByPage(LocalDate date, int page, int size) {
+        String key = generateDailyKey(date);
+        int start = (page - 1) * size;
+        int end = start + size - 1;
+        
+        // 내림차순 정렬 (높은 점수부터)
+        return redisTemplate.opsForZSet().reverseRange(key, start, end);
+    }
+
+    public Long getProductRank(Long productId, LocalDate date) {
+        String key = generateDailyKey(date);
+
+        // reverseRank (높은 점수부터 0번째 순위)
+        Long rank = redisTemplate.opsForZSet().reverseRank(key, productId.toString());
+        return rank != null ? rank + 1 : null; // 1부터 시작하는 순위로 변환
+    }
+
+    public Double getProductScore(Long productId, LocalDate date) {
+        String key = generateDailyKey(date);
+        return redisTemplate.opsForZSet().score(key, productId.toString());
+    }
+
+    public Long getTotalRankingCount(LocalDate date) {
+        String key = generateDailyKey(date);
+        return redisTemplate.opsForZSet().count(key, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/event/EventMapper.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/event/EventMapper.java
@@ -1,0 +1,60 @@
+package com.loopers.infrastructure.event;
+
+import com.loopers.domain.like.event.LikeChangedEvent;
+import com.loopers.domain.order.event.OrderCreatedEvent;
+import com.loopers.domain.product.event.ProductViewedEvent;
+import com.loopers.domain.product.event.StockAdjustedEvent;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+public class EventMapper {
+
+    public Map<String, Object> toConsumerEvent(ProductViewedEvent domainEvent) {
+        Map<String, Object> consumerEvent = new HashMap<>();
+        consumerEvent.put("eventId", domainEvent.getEventId());
+        consumerEvent.put("productId", domainEvent.getProductId());
+        consumerEvent.put("userId", domainEvent.getUserId());
+        consumerEvent.put("occurredAt", domainEvent.getOccurredAt());
+        return consumerEvent;
+    }
+
+    public Map<String, Object> toConsumerEvent(LikeChangedEvent domainEvent) {
+        Map<String, Object> consumerEvent = new HashMap<>();
+        consumerEvent.put("eventId", domainEvent.getEventId());
+        consumerEvent.put("productId", domainEvent.getProductId());
+        consumerEvent.put("userId", domainEvent.getUserId());
+        consumerEvent.put("changeType", domainEvent.getChangeType().name());
+        consumerEvent.put("oldLikeCount", domainEvent.getOldLikeCount());
+        consumerEvent.put("newLikeCount", domainEvent.getNewLikeCount());
+        consumerEvent.put("version", domainEvent.getVersion());
+        consumerEvent.put("occurredAt", domainEvent.getOccurredAt());
+        return consumerEvent;
+    }
+
+    public Map<String, Object> toConsumerEvent(OrderCreatedEvent domainEvent) {
+        Map<String, Object> consumerEvent = new HashMap<>();
+        consumerEvent.put("eventId", domainEvent.getEventId());
+        consumerEvent.put("orderId", domainEvent.getOrderId());
+        consumerEvent.put("orderNumber", domainEvent.getOrderNumber());
+        consumerEvent.put("userId", domainEvent.getUserId());
+        consumerEvent.put("totalAmount", domainEvent.getTotalAmount());
+        consumerEvent.put("orderDate", domainEvent.getOrderDate());
+        consumerEvent.put("occurredAt", domainEvent.getOccurredAt());
+        return consumerEvent;
+    }
+
+    public Map<String, Object> toConsumerEvent(StockAdjustedEvent domainEvent) {
+        Map<String, Object> consumerEvent = new HashMap<>();
+        consumerEvent.put("eventId", domainEvent.getEventId());
+        consumerEvent.put("productId", domainEvent.getProductId());
+        consumerEvent.put("oldStock", domainEvent.getOldStock());
+        consumerEvent.put("newStock", domainEvent.getNewStock());
+        consumerEvent.put("adjustmentAmount", domainEvent.getStockDelta());
+        consumerEvent.put("adjustmentReason", domainEvent.isStockIncreased() ? "RESTOCK" : "SOLD");
+        consumerEvent.put("occurredAt", domainEvent.getOccurredAt());
+        return consumerEvent;
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/event/EventMapper.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/event/EventMapper.java
@@ -7,7 +7,9 @@ import com.loopers.domain.product.event.StockAdjustedEvent;
 import org.springframework.stereotype.Component;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 @Component
 public class EventMapper {
@@ -43,6 +45,21 @@ public class EventMapper {
         consumerEvent.put("totalAmount", domainEvent.getTotalAmount());
         consumerEvent.put("orderDate", domainEvent.getOrderDate());
         consumerEvent.put("occurredAt", domainEvent.getOccurredAt());
+        
+        // OrderItem 정보 추가
+        List<Map<String, Object>> orderItemsMap = domainEvent.getOrderItems().stream()
+                .map(item -> {
+                    Map<String, Object> itemMap = new HashMap<>();
+                    itemMap.put("productId", item.getProductId());
+                    itemMap.put("productName", item.getProductName());
+                    itemMap.put("price", item.getPrice());
+                    itemMap.put("quantity", item.getQuantity());
+                    itemMap.put("itemTotalAmount", item.getItemTotalAmount());
+                    return itemMap;
+                })
+                .collect(Collectors.toList());
+        consumerEvent.put("orderItems", orderItemsMap);
+        
         return consumerEvent;
     }
 

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/external/DataPlatformClientAdapter.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/external/DataPlatformClientAdapter.java
@@ -4,7 +4,7 @@ import com.loopers.domain.external.DataPlatformPort;
 import com.loopers.domain.external.DataPlatformResult;
 import com.loopers.domain.payment.event.PaymentFailedEvent;
 import com.loopers.domain.payment.event.PaymentSuccessEvent;
-import com.loopers.event.OrderCreatedEvent;
+import com.loopers.domain.order.event.OrderCreatedEvent;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeChangePublishImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeChangePublishImpl.java
@@ -1,7 +1,8 @@
 package com.loopers.infrastructure.like;
 
 import com.loopers.domain.like.event.LikeChangePublisher;
-import com.loopers.event.LikeChangedEvent;
+import com.loopers.domain.like.event.LikeChangedEvent;
+import com.loopers.infrastructure.event.EventMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationEventPublisher;
@@ -17,11 +18,12 @@ public class LikeChangePublishImpl implements LikeChangePublisher {
 
     private final KafkaTemplate<String, Object> kafkaTemplate;
     private final ApplicationEventPublisher applicationEventPublisher;
+    private final EventMapper eventMapper;
 
     @Override
     public void publish(LikeChangedEvent event) {
         applicationEventPublisher.publishEvent(event);
-        kafkaTemplate.send(likeTopic, String.valueOf(event.getProductId()), event);
+        kafkaTemplate.send(likeTopic, String.valueOf(event.getProductId()), eventMapper.toConsumerEvent(event));
 
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/order/OrderCreatedPublisherImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/order/OrderCreatedPublisherImpl.java
@@ -1,7 +1,8 @@
 package com.loopers.infrastructure.order;
 
 import com.loopers.domain.order.event.OrderCreatedPublisher;
-import com.loopers.event.OrderCreatedEvent;
+import com.loopers.domain.order.event.OrderCreatedEvent;
+import com.loopers.infrastructure.event.EventMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationEventPublisher;
@@ -17,10 +18,11 @@ public class OrderCreatedPublisherImpl implements OrderCreatedPublisher {
 
     private final KafkaTemplate<String, Object> kafkaTemplate;
     private final ApplicationEventPublisher applicationEventPublisher;
+    private final EventMapper eventMapper;
 
     @Override
     public void publish(OrderCreatedEvent event) {
         applicationEventPublisher.publishEvent(event);
-        kafkaTemplate.send(orderTopic, event.getOrderId().toString(), event);
+        kafkaTemplate.send(orderTopic, event.getOrderId().toString(), eventMapper.toConsumerEvent(event));
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductChangedPublisherImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductChangedPublisherImpl.java
@@ -1,7 +1,7 @@
 package com.loopers.infrastructure.product;
 
 import com.loopers.domain.product.event.ProductChangedPublisher;
-import com.loopers.event.ProductViewedEvent;
+import com.loopers.domain.product.event.ProductViewedEvent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationEventPublisher;

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductDetailViewedPublisherImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductDetailViewedPublisherImpl.java
@@ -1,6 +1,8 @@
 package com.loopers.infrastructure.product;
 
 import com.loopers.domain.product.event.ProductDetailViewedPublisher;
+import com.loopers.domain.product.event.ProductViewedEvent;
+import com.loopers.infrastructure.event.EventMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -18,11 +20,12 @@ public class ProductDetailViewedPublisherImpl implements ProductDetailViewedPubl
 
     private final KafkaTemplate<String, Object> kafkaTemplate;
     private final ApplicationEventPublisher applicationEventPublisher;
+    private final EventMapper eventMapper;
 
 
     @Override
-    public void publish(com.loopers.event.ProductViewedEvent event) {
+    public void publish(ProductViewedEvent event) {
         applicationEventPublisher.publishEvent(event);
-        kafkaTemplate.send(viewTopic, event.getProductId().toString(), event);
+        kafkaTemplate.send(viewTopic, event.getProductId().toString(), eventMapper.toConsumerEvent(event));
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/StockAdjustedPublisherImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/StockAdjustedPublisherImpl.java
@@ -1,7 +1,8 @@
 package com.loopers.infrastructure.product;
 
 import com.loopers.domain.product.event.StockAdjustedPublisher;
-import com.loopers.event.StockAdjustedEvent;
+import com.loopers.domain.product.event.StockAdjustedEvent;
+import com.loopers.infrastructure.event.EventMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -17,9 +18,10 @@ public class StockAdjustedPublisherImpl implements StockAdjustedPublisher {
     private String stockTopic;
 
     private final KafkaTemplate<String, Object> kafkaTemplate;
+    private final EventMapper eventMapper;
 
     @Override
     public void publish(StockAdjustedEvent event) {
-        kafkaTemplate.send(stockTopic, event.getProductId().toString(), event);
+        kafkaTemplate.send(stockTopic, event.getProductId().toString(), eventMapper.toConsumerEvent(event));
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/ranking/RankingApiRedisCacheRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/ranking/RankingApiRedisCacheRepository.java
@@ -1,0 +1,35 @@
+package com.loopers.infrastructure.ranking;
+
+import com.loopers.domain.ranking.RankingApiCacheRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.Set;
+
+@Component
+@RequiredArgsConstructor
+public class RankingApiRedisCacheRepository implements RankingApiCacheRepository {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    @Override
+    public Set<Object> getReversedRank(String key, long start, long end) {
+        return redisTemplate.opsForZSet().reverseRange(key, start, end);
+    }
+
+    @Override
+    public Long getProductRank(String key, Long productId) {
+        return redisTemplate.opsForZSet().reverseRank(key, productId.toString());
+    }
+
+    @Override
+    public Double getProductScore(String key, Long productId) {
+        return redisTemplate.opsForZSet().score(key, productId.toString());
+    }
+
+    @Override
+    public Long getTotalRankingCount(String key) {
+        return redisTemplate.opsForZSet().count(key, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/ranking/RankingQueryAdapter.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/ranking/RankingQueryAdapter.java
@@ -74,6 +74,18 @@ public class RankingQueryAdapter implements RankingQueryRepository {
                     return builder.build();
                 })
                 .toList();
+
+        // 동일 점수 상품들의 정렬 기준 추가
+        List<RankingItem> sortedRankingItems = rankingItems.stream()
+                .sorted((a, b) -> {
+                    int scoreCompare = Double.compare(b.getScore(), a.getScore());
+                    if (scoreCompare == 0) {
+                        // 점수가 같으면 상품 ID 오름차순 (등록일 대용)
+                        return Long.compare(a.getProductId(), b.getProductId());
+                    }
+                    return scoreCompare;
+                })
+                .toList();
         
         // 5. 전체 랭킹 수 조회
         Long totalCount = rankingCacheProcessor.getTotalRankingCount(date);
@@ -82,7 +94,7 @@ public class RankingQueryAdapter implements RankingQueryRepository {
                  date, rankingItems.size(), totalCount);
         
         return RankingPage.builder()
-                .items(rankingItems)
+                .items(sortedRankingItems)
                 .currentPage(page)
                 .pageSize(size)
                 .totalCount(totalCount)

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/ranking/RankingQueryAdapter.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/ranking/RankingQueryAdapter.java
@@ -1,0 +1,93 @@
+package com.loopers.infrastructure.ranking;
+
+import com.loopers.domain.ranking.RankingService;
+import com.loopers.domain.ranking.RankingItem;
+import com.loopers.domain.ranking.RankingPage;
+import com.loopers.domain.ranking.RankingQueryRepository;
+import com.loopers.infrastructure.product.ProductJpaRepository;
+import com.loopers.domain.product.ProductModel;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RankingQueryAdapter implements RankingQueryRepository {
+
+    private final RankingService rankingService;
+    private final ProductJpaRepository productRepository;
+
+    @Override
+    public RankingPage getRankingWithProducts(LocalDate date, int page, int size) {
+        log.debug("랭킹과 상품 정보 통합 조회 시작 - Date: {}, Page: {}, Size: {}", date, page, size);
+        
+        // 1. Redis에서 랭킹 조회
+        Set<Object> rankingProductIds = rankingService.getRankingByPage(date, page, size);
+        
+        if (rankingProductIds.isEmpty()) {
+            log.debug("랭킹 데이터가 없습니다 - Date: {}", date);
+            return RankingPage.empty(page, size);
+        }
+        
+        // 2. 상품 ID를 Long으로 변환
+        List<Long> productIds = rankingProductIds.stream()
+                .map(id -> Long.valueOf(id.toString()))
+                .toList();
+        
+        // 3. DB에서 상품 정보 일괄 조회
+        List<ProductModel> products = productRepository.findAllById(productIds);
+        Map<Long, ProductModel> productMap = products.stream()
+                .collect(Collectors.toMap(ProductModel::getId, Function.identity()));
+        
+        // 4. 랭킹 아이템 정보 구성
+        List<RankingItem> rankingItems = productIds.stream()
+                .map(productId -> {
+                    Long rank = rankingService.getProductRank(productId, date);
+                    Double score = rankingService.getProductScore(productId, date);
+                    ProductModel product = productMap.get(productId);
+                    
+                    RankingItem.RankingItemBuilder builder = RankingItem.builder()
+                            .productId(productId)
+                            .rank(rank)
+                            .score(score);
+                    
+                    if (product != null) {
+                        RankingItem.ProductInfo productInfo = RankingItem.ProductInfo.builder()
+                                .name(product.getName())
+                                .description(product.getDescription())
+                                .price(product.getPrice())
+                                .brandName("Brand " + product.getBrandId()) // 임시로 브랜드 ID 사용
+                                .likeCount(product.getLikesCount())
+                                .build();
+                        
+                        builder = builder.productInfo(productInfo);
+                    }
+                    
+                    return builder.build();
+                })
+                .toList();
+        
+        // 5. 전체 랭킹 수 조회
+        Long totalCount = rankingService.getTotalRankingCount(date);
+        
+        log.debug("랭킹과 상품 정보 통합 조회 완료 - Date: {}, 조회된 아이템 수: {}, 전체 수: {}", 
+                 date, rankingItems.size(), totalCount);
+        
+        return RankingPage.builder()
+                .items(rankingItems)
+                .currentPage(page)
+                .pageSize(size)
+                .totalCount(totalCount)
+                .totalPages((int) Math.ceil((double) totalCount / size))
+                .hasNext(page * size < totalCount)
+                .build();
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Controller.java
@@ -3,6 +3,8 @@ package com.loopers.interfaces.api.product;
 import com.loopers.application.product.ProductApplicationService;
 import com.loopers.application.product.ProductOutputInfo;
 import com.loopers.application.product.ProductQuery;
+import com.loopers.application.ranking.RankingApplicationService;
+import com.loopers.application.ranking.RankingInfo;
 import com.loopers.interfaces.api.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -11,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Slf4j
@@ -20,6 +23,7 @@ import java.util.List;
 public class ProductV1Controller implements ProductV1ApiSpec {
 
     private final ProductApplicationService productApplicationService;
+    private final RankingApplicationService rankingApplicationService;
 
     @Override
     @GetMapping
@@ -51,9 +55,17 @@ public class ProductV1Controller implements ProductV1ApiSpec {
             Long productId) {
 
         ProductOutputInfo product = productApplicationService.getProductDetail(productId, userId);
+        
+        // 오늘 날짜 기준 랭킹 정보 조회
+        RankingInfo rankingInfo = rankingApplicationService.getProductRankingInfo(productId, LocalDate.now());
+        ProductV1Dto.RankingInfoDto rankingDto = null;
+        if (rankingInfo.getRank() != null) {
+            rankingDto = ProductV1Dto.RankingInfoDto.from(rankingInfo.getRank(), rankingInfo.getScore());
+        }
+        
         ProductV1Dto.ProductResponseDto responseBody = ProductV1Dto.ProductResponseDto.from(
                 product.id(), product.name(), product.brandName(), product.categoryName(),
-                product.price(), product.likeCount(), product.stock()
+                product.price(), product.likeCount(), product.stock(), rankingDto
         );
 
         return ApiResponse.success(responseBody);

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Dto.java
@@ -37,8 +37,22 @@ public class ProductV1Dto {
             String categoryName,
             int price,
             int likeCount,
-            int stockCount
+            int stockCount,
+            RankingInfoDto rankingInfo
     ) {
+        public static ProductResponseDto from(
+                Long id,
+                String productName,
+                String brandName,
+                String categoryName,
+                int price,
+                int likeCount,
+                int stockCount,
+                RankingInfoDto rankingInfo
+        ) {
+            return new ProductResponseDto(id, productName, brandName, categoryName, price, likeCount, stockCount, rankingInfo);
+        }
+
         public static ProductResponseDto from(
                 Long id,
                 String productName,
@@ -48,7 +62,7 @@ public class ProductV1Dto {
                 int likeCount,
                 int stockCount
         ) {
-            return new ProductResponseDto(id, productName, brandName, categoryName, price, likeCount, stockCount);
+            return new ProductResponseDto(id, productName, brandName, categoryName, price, likeCount, stockCount, null);
         }
     }
 
@@ -67,7 +81,8 @@ public class ProductV1Dto {
                             product.categoryName(),
                             product.price(),
                             product.likeCount(),
-                            product.stock()
+                            product.stock(),
+                            null // 목록에서는 랭킹 정보 제외
                     )).toList();
 
             // 마지막 상품의 정보로 다음 커서 생성
@@ -91,6 +106,15 @@ public class ProductV1Dto {
                     lastProduct.price(),
                     lastProduct.lastCreatedAt()
             );
+        }
+    }
+
+    public record RankingInfoDto(
+            Long rank,
+            Double score
+    ) {
+        public static RankingInfoDto from(Long rank, Double score) {
+            return new RankingInfoDto(rank, score);
         }
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1ApiSpec.java
@@ -1,0 +1,29 @@
+package com.loopers.interfaces.api.ranking;
+
+import com.loopers.interfaces.api.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.time.LocalDate;
+
+@Tag(name = "Ranking API", description = "상품 랭킹 조회 API")
+public interface RankingV1ApiSpec {
+
+    @Operation(
+            summary = "일간 상품 랭킹 조회",
+            description = "특정 날짜의 상품 랭킹을 페이지네이션으로 조회합니다."
+    )
+    ApiResponse<RankingV1Dto.RankingPageResponse> getRankings(
+            @Parameter(description = "조회할 날짜 (yyyyMMdd 형식)", required = true, example = "20231215")
+            @RequestParam(name = "date") @DateTimeFormat(pattern = "yyyyMMdd") LocalDate date,
+            
+            @Parameter(description = "페이지당 항목 수 (1-100, 기본값: 20)", example = "20")
+            @RequestParam(name = "size", defaultValue = "20") int size,
+            
+            @Parameter(description = "페이지 번호 (1부터 시작, 기본값: 1)", example = "1")
+            @RequestParam(name = "page", defaultValue = "1") int page
+    );
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1Controller.java
@@ -1,0 +1,42 @@
+package com.loopers.interfaces.api.ranking;
+
+import com.loopers.application.ranking.RankingApplicationService;
+import com.loopers.application.ranking.RankingPageInfo;
+import com.loopers.interfaces.api.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/rankings")
+@RequiredArgsConstructor
+public class RankingV1Controller implements RankingV1ApiSpec {
+
+    private final RankingApplicationService rankingApplicationService;
+
+    @GetMapping
+    public ApiResponse<RankingV1Dto.RankingPageResponse> getRankings(
+            @RequestParam(name = "date") @DateTimeFormat(pattern = "yyyyMMdd") LocalDate date,
+            @RequestParam(name = "size", defaultValue = "20") int size,
+            @RequestParam(name = "page", defaultValue = "1") int page) {
+        
+        log.info("랭킹 페이지 조회 요청 - Date: {}, Page: {}, Size: {}", date, page, size);
+        
+        // 페이지 유효성 검증
+        if (page < 1) {
+            page = 1;
+        }
+        if (size < 1 || size > 100) {
+            size = 20;
+        }
+        
+        RankingPageInfo rankingPageInfo = rankingApplicationService.getRankingPage(date, page, size);
+        RankingV1Dto.RankingPageResponse response = RankingV1Dto.RankingPageResponse.from(rankingPageInfo);
+        
+        return ApiResponse.success(response);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1Dto.java
@@ -1,0 +1,74 @@
+package com.loopers.interfaces.api.ranking;
+
+import com.loopers.application.ranking.RankingItemInfo;
+import com.loopers.application.ranking.RankingPageInfo;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class RankingV1Dto {
+
+    @Getter
+    @Builder
+    public static class RankingPageResponse {
+        private final LocalDate date;
+        private final int page;
+        private final int size;
+        private final int totalItems;
+        private final List<RankingItemResponse> items;
+
+        public static RankingPageResponse from(RankingPageInfo info) {
+            return RankingPageResponse.builder()
+                    .date(info.getDate())
+                    .page(info.getPage())
+                    .size(info.getSize())
+                    .totalItems(info.getTotalItems())
+                    .items(info.getItems().stream()
+                            .map(RankingItemResponse::from)
+                            .collect(Collectors.toList()))
+                    .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    public static class RankingItemResponse {
+        private final Long productId;
+        private final Long rank;
+        private final Double score;
+        private final ProductInfoResponse productInfo;
+
+        public static RankingItemResponse from(RankingItemInfo info) {
+            return RankingItemResponse.builder()
+                    .productId(info.getProductId())
+                    .rank(info.getRank())
+                    .score(info.getScore())
+                    .productInfo(info.getProductInfo() != null ? 
+                            ProductInfoResponse.from(info.getProductInfo()) : null)
+                    .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    public static class ProductInfoResponse {
+        private final String name;
+        private final String description;
+        private final int price;
+        private final String brandName;
+        private final long likeCount;
+
+        public static ProductInfoResponse from(RankingItemInfo.ProductInfo info) {
+            return ProductInfoResponse.builder()
+                    .name(info.getName())
+                    .description(info.getDescription())
+                    .price(info.getPrice())
+                    .brandName(info.getBrandName())
+                    .likeCount(info.getLikeCount())
+                    .build();
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/application/product/UserActingTrackingForProductEventHandlerTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/product/UserActingTrackingForProductEventHandlerTest.java
@@ -3,7 +3,7 @@ package com.loopers.application.product;
 import com.loopers.domain.product.event.ClickContext;
 import com.loopers.domain.product.event.ProductClickedEvent;
 import com.loopers.domain.user.UserId;
-import com.loopers.event.ProductViewedEvent;
+import com.loopers.domain.product.event.ProductViewedEvent;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;

--- a/apps/commerce-api/src/test/java/com/loopers/interfaces/kafka/ProductViewPublishTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/interfaces/kafka/ProductViewPublishTest.java
@@ -1,6 +1,6 @@
 package com.loopers.interfaces.kafka;
 
-import com.loopers.event.ProductViewedEvent;
+import com.loopers.domain.product.event.ProductViewedEvent;
 import com.loopers.infrastructure.product.ProductDetailViewedPublisherImpl;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/apps/commerce-collector/src/main/java/com/loopers/application/event/ConsumerEventMapper.java
+++ b/apps/commerce-collector/src/main/java/com/loopers/application/event/ConsumerEventMapper.java
@@ -1,4 +1,4 @@
-package com.loopers.infrastructure.event;
+package com.loopers.application.event;
 
 import com.loopers.event.*;
 import org.springframework.stereotype.Component;

--- a/apps/commerce-collector/src/main/java/com/loopers/application/event/MetricsApplicationService.java
+++ b/apps/commerce-collector/src/main/java/com/loopers/application/event/MetricsApplicationService.java
@@ -66,9 +66,20 @@ public class MetricsApplicationService {
             log.debug("이미 처리된 주문 생성 이벤트 - EventId: {}", eventId);
             return;
         }
+        
+        // 주문 아이템별 판매 수와 금액 업데이트
+        event.getOrderItems().forEach(item -> {
+            long totalAmount = (long) item.getPrice() * item.getQuantity();
+            productMetricsRepository.upsertSalesCount(item.getProductId(), totalAmount);
+            
+            log.debug("주문 상품 메트릭 업데이트 - ProductId: {}, Amount: {}", 
+                     item.getProductId(), totalAmount);
+        });
+        
         idempotentProcessor.markAsProcessed(eventId, CONSUMER_GROUP);
 
-        log.info("주문 메트릭 업데이트 완료 - OrderId: {}", event.getOrderId());
+        log.info("주문 메트릭 업데이트 완료 - OrderId: {}, 상품 수: {}", 
+                 event.getOrderId(), event.getOrderItems().size());
     }
 
 

--- a/apps/commerce-collector/src/main/java/com/loopers/application/event/MetricsApplicationService.java
+++ b/apps/commerce-collector/src/main/java/com/loopers/application/event/MetricsApplicationService.java
@@ -2,12 +2,13 @@ package com.loopers.application.event;
 
 
 import com.loopers.domain.repository.ProductMetricsRepository;
-import com.loopers.event.LikeChangedEvent;
-import com.loopers.event.OrderCreatedEvent;
-import com.loopers.event.ProductViewedEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
 
 @Slf4j
 @Component
@@ -18,69 +19,54 @@ public class MetricsApplicationService {
     private final ProductMetricsRepository productMetricsRepository;
 
     private static final String CONSUMER_GROUP = "metrics-group";
-
-    public void handleProductViewedEvent(ProductViewedEvent event) {
-        String eventId = event.getEventId();
-
-        if (idempotentProcessor.isAlreadyProcessed(eventId, CONSUMER_GROUP)) {
-            log.debug("이미 처리된 상품 조회 이벤트 - EventId: {}", eventId);
-            return;
-        }
-
-        // 조회수 증가
-        productMetricsRepository.upsertViewCount(
-                event.getProductId(),
-                event.getOccurredAt()
-        );
-
-        idempotentProcessor.markAsProcessed(eventId, CONSUMER_GROUP);
-
-        log.debug("상품 조회 메트릭 업데이트 완료 - ProductId: {}", event.getProductId());
-    }
-
-    public void handleLikeChangedEvent(LikeChangedEvent event) {
-        String eventId = event.getEventId();
-
-        if (idempotentProcessor.isAlreadyProcessed(eventId, CONSUMER_GROUP)) {
-            log.debug("이미 처리된 좋아요 변경 이벤트 - EventId: {}", eventId);
-            return;
-        }
-
-        // 좋아요 수 업데이트
-        productMetricsRepository.upsertLikeCount(
-                event.getProductId(),
-                (long) event.getNewLikeCount(),
-                event.getOccurredAt()
-        );
-
-        idempotentProcessor.markAsProcessed(eventId, CONSUMER_GROUP);
-
-        log.debug("좋아요 메트릭 업데이트 완료 - ProductId: {}, LikeCount: {}",
-                event.getProductId(), event.getNewLikeCount());
-    }
-
-    public void handleOrderCreatedEvent(OrderCreatedEvent event) {
-        String eventId = event.getEventId();
-
-        if (idempotentProcessor.isAlreadyProcessed(eventId, CONSUMER_GROUP)) {
-            log.debug("이미 처리된 주문 생성 이벤트 - EventId: {}", eventId);
-            return;
-        }
+    
+    /**
+     * 배치 메트릭 업데이트 - 집계된 데이터를 배치로 처리
+     */
+    @Transactional
+    public void updateMetricsBatch(ProductMetricsAggregation aggregation) {
+        log.info("배치 메트릭 업데이트 시작 - View: {}, Like: {}, Sales: {}", 
+                aggregation.getViewCounts().size(),
+                aggregation.getLikeUpdates().size(),
+                aggregation.getSalesData().size());
         
-        // 주문 아이템별 판매 수와 금액 업데이트
-        event.getOrderItems().forEach(item -> {
-            long totalAmount = (long) item.getPrice() * item.getQuantity();
-            productMetricsRepository.upsertSalesCount(item.getProductId(), totalAmount);
+        // View 배치 업데이트
+        aggregation.getViewCounts().values().forEach(viewCount -> 
+            productMetricsRepository.incrementViewCountBatch(
+                viewCount.getProductId(), 
+                viewCount.getCount(),
+                viewCount.getLastViewedAt()
+            ));
+        
+        // Like 배치 업데이트
+        aggregation.getLikeUpdates().values().forEach(likeUpdate ->
+            productMetricsRepository.updateLikeCountBatch(
+                likeUpdate.getProductId(),
+                likeUpdate.getFinalLikeCount(), 
+                likeUpdate.getLastLikedAt()
+            ));
+        
+        // Sales 배치 업데이트
+        aggregation.getSalesData().values().forEach(salesData ->
+            productMetricsRepository.incrementSalesCountBatch(
+                salesData.getProductId(),
+                salesData.getSalesCount(),
+                salesData.getTotalAmount()
+            ));
             
-            log.debug("주문 상품 메트릭 업데이트 - ProductId: {}, Amount: {}", 
-                     item.getProductId(), totalAmount);
+        log.info("배치 메트릭 업데이트 완료");
+    }
+    
+    /**
+     * 이벤트 전체를 처리 완료로 마크
+     */
+    public void markEventsAsProcessed(List<Map<String, Object>> eventDataList) {
+        eventDataList.forEach(eventData -> {
+            String eventId = (String) eventData.get("eventId");
+            idempotentProcessor.markAsProcessed(eventId, CONSUMER_GROUP);
         });
         
-        idempotentProcessor.markAsProcessed(eventId, CONSUMER_GROUP);
-
-        log.info("주문 메트릭 업데이트 완료 - OrderId: {}, 상품 수: {}", 
-                 event.getOrderId(), event.getOrderItems().size());
+        log.debug("이벤트 멱등성 마크 완료 - 처리된 이벤트 수: {}", eventDataList.size());
     }
-
 
 }

--- a/apps/commerce-collector/src/main/java/com/loopers/application/event/MetricsBatchAggregator.java
+++ b/apps/commerce-collector/src/main/java/com/loopers/application/event/MetricsBatchAggregator.java
@@ -1,0 +1,199 @@
+package com.loopers.application.event;
+
+import com.loopers.event.LikeChangedEvent;
+import com.loopers.event.OrderCreatedEvent;
+import com.loopers.event.ProductViewedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.time.ZonedDateTime;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MetricsBatchAggregator {
+    
+    private final ConsumerEventMapper eventMapper;
+    
+    public ProductMetricsAggregation aggregateEvents(List<Map<String, Object>> eventDataList) {
+        log.debug("이벤트 배치 집계 시작 - 이벤트 수: {}", eventDataList.size());
+        
+        // 집계용 Map들 (Thread-safe)
+        Map<Long, AtomicInteger> viewCounts = new ConcurrentHashMap<>();
+        Map<Long, ZonedDateTime> viewTimestamps = new ConcurrentHashMap<>();
+        Map<Long, Long> latestLikeCounts = new ConcurrentHashMap<>();
+        Map<Long, ZonedDateTime> likeTimestamps = new ConcurrentHashMap<>();
+        Map<Long, AtomicInteger> salesCounts = new ConcurrentHashMap<>();
+        Map<Long, AtomicLong> salesAmounts = new ConcurrentHashMap<>();
+        
+        Set<String> processedEventIds = new HashSet<>();
+        
+        for (Map<String, Object> eventData : eventDataList) {
+            String eventId = (String) eventData.get("eventId");
+            
+            // 중복 이벤트 스킵
+            if (!processedEventIds.add(eventId)) {
+                log.debug("중복 이벤트 스킵 - EventId: {}", eventId);
+                continue;
+            }
+            
+            String eventType = determineEventType(eventData);
+            
+            switch (eventType) {
+                case "VIEW" -> processViewEvent(eventData, viewCounts, viewTimestamps);
+                case "LIKE" -> processLikeEvent(eventData, latestLikeCounts, likeTimestamps);
+                case "ORDER" -> processOrderEvent(eventData, salesCounts, salesAmounts);
+                default -> log.warn("알 수 없는 이벤트 타입: {}", eventType);
+            }
+        }
+        
+        ProductMetricsAggregation aggregation = buildAggregation(
+            viewCounts, viewTimestamps,
+            latestLikeCounts, likeTimestamps,
+            salesCounts, salesAmounts
+        );
+        
+        log.debug("이벤트 배치 집계 완료 - View: {}, Like: {}, Sales: {}", 
+                 aggregation.getViewCounts().size(),
+                 aggregation.getLikeUpdates().size(),
+                 aggregation.getSalesData().size());
+        
+        return aggregation;
+    }
+    
+    private String determineEventType(Map<String, Object> eventData) {
+        // 이벤트 타입 결정 로직
+        if (eventData.containsKey("productId") && eventData.containsKey("userId") 
+            && !eventData.containsKey("changeType") && !eventData.containsKey("orderItems")) {
+            return "VIEW";
+        } else if (eventData.containsKey("changeType")) {
+            return "LIKE";
+        } else if (eventData.containsKey("orderItems")) {
+            return "ORDER";
+        }
+        return "UNKNOWN";
+    }
+    
+    private void processViewEvent(Map<String, Object> eventData,
+                                 Map<Long, AtomicInteger> viewCounts,
+                                 Map<Long, ZonedDateTime> viewTimestamps) {
+        try {
+            ProductViewedEvent event = eventMapper.toProductViewedEvent(eventData);
+            Long productId = event.getProductId();
+            
+            // 조회수 집계
+            viewCounts.computeIfAbsent(productId, k -> new AtomicInteger(0))
+                     .incrementAndGet();
+            
+            // 최신 조회 시간 업데이트
+            viewTimestamps.merge(productId, event.getOccurredAt(),
+                (existing, incoming) -> incoming.isAfter(existing) ? incoming : existing);
+                
+            log.debug("조회 이벤트 집계 - ProductId: {}", productId);
+        } catch (Exception e) {
+            log.error("조회 이벤트 처리 실패: {}", e.getMessage(), e);
+        }
+    }
+    
+    private void processLikeEvent(Map<String, Object> eventData,
+                                 Map<Long, Long> latestLikeCounts,
+                                 Map<Long, ZonedDateTime> likeTimestamps) {
+        try {
+            LikeChangedEvent event = eventMapper.toLikeChangedEvent(eventData);
+            
+            // LIKE 타입만 처리
+            if ("LIKE".equals(event.getChangeType())) {
+                Long productId = event.getProductId();
+                
+                // 최종 좋아요 수 (배치 내 최신값)
+                latestLikeCounts.put(productId, (long) event.getNewLikeCount());
+                likeTimestamps.merge(productId, event.getOccurredAt(),
+                    (existing, incoming) -> incoming.isAfter(existing) ? incoming : existing);
+                    
+                log.debug("좋아요 이벤트 집계 - ProductId: {}, LikeCount: {}", 
+                         productId, event.getNewLikeCount());
+            }
+        } catch (Exception e) {
+            log.error("좋아요 이벤트 처리 실패: {}", e.getMessage(), e);
+        }
+    }
+    
+    private void processOrderEvent(Map<String, Object> eventData,
+                                  Map<Long, AtomicInteger> salesCounts,
+                                  Map<Long, AtomicLong> salesAmounts) {
+        try {
+            OrderCreatedEvent event = eventMapper.toOrderCreatedEvent(eventData);
+            
+            event.getOrderItems().forEach(item -> {
+                Long productId = item.getProductId();
+                long itemAmount = (long) item.getPrice() * item.getQuantity();
+                
+                // 판매 건수 집계
+                salesCounts.computeIfAbsent(productId, k -> new AtomicInteger(0))
+                          .incrementAndGet();
+                
+                // 판매 금액 집계
+                salesAmounts.computeIfAbsent(productId, k -> new AtomicLong(0))
+                           .addAndGet(itemAmount);
+                           
+                log.debug("주문 이벤트 집계 - ProductId: {}, Amount: {}", productId, itemAmount);
+            });
+        } catch (Exception e) {
+            log.error("주문 이벤트 처리 실패: {}", e.getMessage(), e);
+        }
+    }
+    
+    private ProductMetricsAggregation buildAggregation(
+            Map<Long, AtomicInteger> viewCounts,
+            Map<Long, ZonedDateTime> viewTimestamps,
+            Map<Long, Long> latestLikeCounts,
+            Map<Long, ZonedDateTime> likeTimestamps,
+            Map<Long, AtomicInteger> salesCounts,
+            Map<Long, AtomicLong> salesAmounts) {
+        
+        // ViewCount 변환
+        Map<Long, ProductMetricsAggregation.ViewCount> viewCountMap = new ConcurrentHashMap<>();
+        viewCounts.forEach((productId, count) -> {
+            viewCountMap.put(productId, ProductMetricsAggregation.ViewCount.builder()
+                    .productId(productId)
+                    .count(count.get())
+                    .lastViewedAt(viewTimestamps.get(productId))
+                    .build());
+        });
+        
+        // LikeUpdate 변환
+        Map<Long, ProductMetricsAggregation.LikeUpdate> likeUpdateMap = new ConcurrentHashMap<>();
+        latestLikeCounts.forEach((productId, likeCount) -> {
+            likeUpdateMap.put(productId, ProductMetricsAggregation.LikeUpdate.builder()
+                    .productId(productId)
+                    .finalLikeCount(likeCount)
+                    .lastLikedAt(likeTimestamps.get(productId))
+                    .build());
+        });
+        
+        // SalesData 변환
+        Map<Long, ProductMetricsAggregation.SalesData> salesDataMap = new ConcurrentHashMap<>();
+        salesCounts.forEach((productId, count) -> {
+            Long totalAmount = salesAmounts.get(productId).get();
+            salesDataMap.put(productId, ProductMetricsAggregation.SalesData.builder()
+                    .productId(productId)
+                    .salesCount(count.get())
+                    .totalAmount(totalAmount)
+                    .build());
+        });
+        
+        return ProductMetricsAggregation.builder()
+                .viewCounts(viewCountMap)
+                .likeUpdates(likeUpdateMap)
+                .salesData(salesDataMap)
+                .build();
+    }
+}

--- a/apps/commerce-collector/src/main/java/com/loopers/application/event/ProductMetricsAggregation.java
+++ b/apps/commerce-collector/src/main/java/com/loopers/application/event/ProductMetricsAggregation.java
@@ -1,0 +1,39 @@
+package com.loopers.application.event;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.ZonedDateTime;
+import java.util.Map;
+
+@Builder
+@Getter
+public class ProductMetricsAggregation {
+    private final Map<Long, ViewCount> viewCounts;
+    private final Map<Long, LikeUpdate> likeUpdates;
+    private final Map<Long, SalesData> salesData;
+    
+    @Builder
+    @Getter
+    public static class ViewCount {
+        private final Long productId;
+        private final int count;
+        private final ZonedDateTime lastViewedAt;
+    }
+    
+    @Builder
+    @Getter
+    public static class LikeUpdate {
+        private final Long productId;
+        private final Long finalLikeCount;
+        private final ZonedDateTime lastLikedAt;
+    }
+    
+    @Builder
+    @Getter
+    public static class SalesData {
+        private final Long productId;
+        private final int salesCount;
+        private final Long totalAmount;
+    }
+}

--- a/apps/commerce-collector/src/main/java/com/loopers/application/event/RankingCacheService.java
+++ b/apps/commerce-collector/src/main/java/com/loopers/application/event/RankingCacheService.java
@@ -1,0 +1,98 @@
+package com.loopers.application.event;
+
+import com.loopers.domain.entity.ProductMetrics;
+import com.loopers.domain.repository.ProductMetricsRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Set;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RankingCacheService {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final ProductMetricsRepository productMetricsRepository;
+    
+    private static final String RANKING_KEY_PREFIX = "ranking:all:";
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
+    private static final long TTL_DAYS = 2L;
+    
+    // 이벤트별 가중치
+    private static final double VIEW_WEIGHT = 0.1;
+    private static final double LIKE_WEIGHT = 0.2;
+    private static final double ORDER_WEIGHT = 0.6;
+
+    public String generateDailyKey(LocalDate date) {
+        return RANKING_KEY_PREFIX + date.format(DATE_FORMATTER);
+    }
+
+    public String generateDailyKey() {
+        return generateDailyKey(LocalDate.now());
+    }
+
+    public void syncRankingFromDatabase(LocalDate date) {
+        log.info("DB에서 Redis로 랭킹 동기화 시작 - Date: {}", date);
+        
+        String key = generateDailyKey(date);
+        
+        // 기존 랭킹 데이터 삭제
+        redisTemplate.delete(key);
+        
+        // DB에서 메트릭 데이터 조회
+        List<ProductMetrics> metricsList = productMetricsRepository.findAllByLastUpdatedDate(date);
+        
+        for (ProductMetrics metrics : metricsList) {
+            double score = calculateRankingScore(metrics);
+            redisTemplate.opsForZSet().add(key, metrics.getProductId().toString(), score);
+        }
+        
+        setTtlIfNew(key);
+        
+        log.info("DB에서 Redis로 랭킹 동기화 완료 - Date: {}, 처리된 상품 수: {}", date, metricsList.size());
+    }
+    
+    private double calculateRankingScore(ProductMetrics metrics) {
+        double viewScore = VIEW_WEIGHT * metrics.getViewCount();
+        double likeScore = LIKE_WEIGHT * metrics.getLikeCount();
+        double orderScore = ORDER_WEIGHT * Math.log10(metrics.getTotalSalesAmount() + 1);
+        
+        return viewScore + likeScore + orderScore;
+    }
+
+    public Set<Object> getRankingByPage(LocalDate date, int page, int size) {
+        String key = generateDailyKey(date);
+        int start = (page - 1) * size;
+        int end = start + size - 1;
+        
+        // 내림차순 정렬 (높은 점수부터)
+        return redisTemplate.opsForZSet().reverseRange(key, start, end);
+    }
+
+    public Long getProductRank(Long productId, LocalDate date) {
+        String key = generateDailyKey(date);
+
+        Long rank = redisTemplate.opsForZSet().reverseRank(key, productId.toString());
+        return rank != null ? rank + 1 : null;
+    }
+
+    public Double getProductScore(Long productId, LocalDate date) {
+        String key = generateDailyKey(date);
+        return redisTemplate.opsForZSet().score(key, productId.toString());
+    }
+
+    private void setTtlIfNew(String key) {
+
+        Long ttl = redisTemplate.getExpire(key);
+        if (ttl == -1) { // TTL이 설정되지 않은 경우
+            redisTemplate.expire(key, java.time.Duration.ofDays(TTL_DAYS));
+            log.debug("랭킹 키 TTL 설정 - Key: {}, TTL: {}일", key, TTL_DAYS);
+        }
+    }
+}

--- a/apps/commerce-collector/src/main/java/com/loopers/application/event/RankingCacheService.java
+++ b/apps/commerce-collector/src/main/java/com/loopers/application/event/RankingCacheService.java
@@ -37,17 +37,16 @@ public class RankingCacheService {
      */
     public void updateDailyRanking(LocalDate date) {
         String key = generateDailyKey(date);
-        List<ProductMetrics> allMetrics = productMetricsRepository.findAll(); // DB에서 모든 상품 메트릭 조회
+        List<ProductMetrics> dateMetrics = productMetricsRepository.findAllByLastUpdatedDate(date);
 
-        for (ProductMetrics metric : allMetrics) {
+        for (ProductMetrics metric : dateMetrics) {
             double score = calculateRankingScore(metric);
             if (score > 0) {
                 cacheRepository.addOrUpdateScore(key, metric.getProductId().toString(), score);
             }
         }
-
         cacheRepository.expire(key, RANKING_TTL);
-        log.info("일간 랭킹 업데이트 완료 - 키: {}", key);
+        log.info("일간 랭킹 업데이트 완료 - 날짜: {}, 키: {}, 처리된 상품 수: {}", date, key, dateMetrics.size());
     }
 
     /**

--- a/apps/commerce-collector/src/main/java/com/loopers/application/event/RankingCacheService.java
+++ b/apps/commerce-collector/src/main/java/com/loopers/application/event/RankingCacheService.java
@@ -2,97 +2,71 @@ package com.loopers.application.event;
 
 import com.loopers.domain.entity.ProductMetrics;
 import com.loopers.domain.repository.ProductMetricsRepository;
+import com.loopers.domain.repository.RankingCacheRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
+import java.time.Duration;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
-import java.util.Set;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class RankingCacheService {
 
-    private final RedisTemplate<String, Object> redisTemplate;
     private final ProductMetricsRepository productMetricsRepository;
-    
+    private final RankingCacheRepository cacheRepository;
+
     private static final String RANKING_KEY_PREFIX = "ranking:all:";
-    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
-    private static final long TTL_DAYS = 2L;
-    
+    private static final Duration RANKING_TTL = Duration.ofDays(2);
+
     // 이벤트별 가중치
     private static final double VIEW_WEIGHT = 0.1;
     private static final double LIKE_WEIGHT = 0.2;
     private static final double ORDER_WEIGHT = 0.6;
 
     public String generateDailyKey(LocalDate date) {
-        return RANKING_KEY_PREFIX + date.format(DATE_FORMATTER);
+        return RANKING_KEY_PREFIX + date.format(DateTimeFormatter.ofPattern("yyyyMMdd"));
     }
 
-    public String generateDailyKey() {
-        return generateDailyKey(LocalDate.now());
-    }
-
-    public void syncRankingFromDatabase(LocalDate date) {
-        log.info("DB에서 Redis로 랭킹 동기화 시작 - Date: {}", date);
-        
+    /**
+     * Redis 랭킹을 업데이트
+     */
+    public void updateDailyRanking(LocalDate date) {
         String key = generateDailyKey(date);
-        
-        // 기존 랭킹 데이터 삭제
-        redisTemplate.delete(key);
-        
-        // DB에서 메트릭 데이터 조회
-        List<ProductMetrics> metricsList = productMetricsRepository.findAllByLastUpdatedDate(date);
-        
-        for (ProductMetrics metrics : metricsList) {
-            double score = calculateRankingScore(metrics);
-            redisTemplate.opsForZSet().add(key, metrics.getProductId().toString(), score);
+        List<ProductMetrics> allMetrics = productMetricsRepository.findAll(); // DB에서 모든 상품 메트릭 조회
+
+        for (ProductMetrics metric : allMetrics) {
+            double score = calculateRankingScore(metric);
+            if (score > 0) {
+                cacheRepository.addOrUpdateScore(key, metric.getProductId().toString(), score);
+            }
         }
-        
-        setTtlIfNew(key);
-        
-        log.info("DB에서 Redis로 랭킹 동기화 완료 - Date: {}, 처리된 상품 수: {}", date, metricsList.size());
+
+        cacheRepository.expire(key, RANKING_TTL);
+        log.info("일간 랭킹 업데이트 완료 - 키: {}", key);
     }
-    
+
+    /**
+     * 전날의 랭킹을 다음날의 랭킹으로 이월.
+     */
+    public void carryOverRankingScores() {
+        String todayKey = generateDailyKey(LocalDate.now());
+        String tomorrowKey = generateDailyKey(LocalDate.now().plusDays(1));
+
+        cacheRepository.unionAndStore(todayKey, tomorrowKey);
+        cacheRepository.expire(tomorrowKey, RANKING_TTL);
+        log.info("랭킹 점수 이월 완료: {} -> {}", todayKey, tomorrowKey);
+    }
+
     private double calculateRankingScore(ProductMetrics metrics) {
         double viewScore = VIEW_WEIGHT * metrics.getViewCount();
         double likeScore = LIKE_WEIGHT * metrics.getLikeCount();
         double orderScore = ORDER_WEIGHT * Math.log10(metrics.getTotalSalesAmount() + 1);
-        
         return viewScore + likeScore + orderScore;
     }
 
-    public Set<Object> getRankingByPage(LocalDate date, int page, int size) {
-        String key = generateDailyKey(date);
-        int start = (page - 1) * size;
-        int end = start + size - 1;
-        
-        // 내림차순 정렬 (높은 점수부터)
-        return redisTemplate.opsForZSet().reverseRange(key, start, end);
-    }
-
-    public Long getProductRank(Long productId, LocalDate date) {
-        String key = generateDailyKey(date);
-
-        Long rank = redisTemplate.opsForZSet().reverseRank(key, productId.toString());
-        return rank != null ? rank + 1 : null;
-    }
-
-    public Double getProductScore(Long productId, LocalDate date) {
-        String key = generateDailyKey(date);
-        return redisTemplate.opsForZSet().score(key, productId.toString());
-    }
-
-    private void setTtlIfNew(String key) {
-
-        Long ttl = redisTemplate.getExpire(key);
-        if (ttl == -1) { // TTL이 설정되지 않은 경우
-            redisTemplate.expire(key, java.time.Duration.ofDays(TTL_DAYS));
-            log.debug("랭킹 키 TTL 설정 - Key: {}, TTL: {}일", key, TTL_DAYS);
-        }
-    }
 }

--- a/apps/commerce-collector/src/main/java/com/loopers/domain/entity/ProductMetrics.java
+++ b/apps/commerce-collector/src/main/java/com/loopers/domain/entity/ProductMetrics.java
@@ -28,6 +28,9 @@ public class ProductMetrics extends BaseEntity {
     @Column(name = "sales_count", nullable = false)
     private Long salesCount = 0L;
 
+    @Column(name = "total_sales_amount", nullable = false)
+    private Long totalSalesAmount = 0L;
+
     @Column(name = "last_viewed_at")
     private ZonedDateTime lastViewedAt;
 
@@ -50,8 +53,9 @@ public class ProductMetrics extends BaseEntity {
         this.lastLikedAt = likedAt;
     }
 
-    public void incrementSalesCount() {
+    public void incrementSalesCount(Long amount) {
         this.salesCount++;
+        this.totalSalesAmount += amount;
     }
 
 }

--- a/apps/commerce-collector/src/main/java/com/loopers/domain/repository/ProductMetricsRepository.java
+++ b/apps/commerce-collector/src/main/java/com/loopers/domain/repository/ProductMetricsRepository.java
@@ -2,6 +2,7 @@ package com.loopers.domain.repository;
 
 import com.loopers.domain.entity.ProductMetrics;
 
+import java.time.LocalDate;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -15,5 +16,5 @@ public interface ProductMetricsRepository {
     void updateLikeCountBatch(Long productId, Long finalCount, ZonedDateTime lastLikedAt);
     void incrementSalesCountBatch(Long productId, int salesCount, Long totalAmount);
 
-    List<ProductMetrics> findAll();
+    List<ProductMetrics> findAllByLastUpdatedDate(LocalDate date);
 }

--- a/apps/commerce-collector/src/main/java/com/loopers/domain/repository/ProductMetricsRepository.java
+++ b/apps/commerce-collector/src/main/java/com/loopers/domain/repository/ProductMetricsRepository.java
@@ -2,7 +2,9 @@ package com.loopers.domain.repository;
 
 import com.loopers.domain.entity.ProductMetrics;
 
+import java.time.LocalDate;
 import java.time.ZonedDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface ProductMetricsRepository {
@@ -11,4 +13,7 @@ public interface ProductMetricsRepository {
 
     ProductMetrics upsertViewCount(Long productId, ZonedDateTime viewedAt);
     ProductMetrics upsertLikeCount(Long productId, Long newLikeCount, ZonedDateTime likedAt);
+    ProductMetrics upsertSalesCount(Long productId, Long amount);
+    
+    List<ProductMetrics> findAllByLastUpdatedDate(LocalDate date);
 }

--- a/apps/commerce-collector/src/main/java/com/loopers/domain/repository/ProductMetricsRepository.java
+++ b/apps/commerce-collector/src/main/java/com/loopers/domain/repository/ProductMetricsRepository.java
@@ -2,7 +2,6 @@ package com.loopers.domain.repository;
 
 import com.loopers.domain.entity.ProductMetrics;
 
-import java.time.LocalDate;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -11,14 +10,10 @@ public interface ProductMetricsRepository {
     Optional<ProductMetrics> findByProductId(Long productId);
     ProductMetrics save(ProductMetrics productMetrics);
 
-    ProductMetrics upsertViewCount(Long productId, ZonedDateTime viewedAt);
-    ProductMetrics upsertLikeCount(Long productId, Long newLikeCount, ZonedDateTime likedAt);
-    ProductMetrics upsertSalesCount(Long productId, Long amount);
-    
-    List<ProductMetrics> findAllByLastUpdatedDate(LocalDate date);
-    
     // 배치 처리 메서드들
     void incrementViewCountBatch(Long productId, int incrementCount, ZonedDateTime lastViewedAt);
     void updateLikeCountBatch(Long productId, Long finalCount, ZonedDateTime lastLikedAt);
     void incrementSalesCountBatch(Long productId, int salesCount, Long totalAmount);
+
+    List<ProductMetrics> findAll();
 }

--- a/apps/commerce-collector/src/main/java/com/loopers/domain/repository/ProductMetricsRepository.java
+++ b/apps/commerce-collector/src/main/java/com/loopers/domain/repository/ProductMetricsRepository.java
@@ -16,4 +16,9 @@ public interface ProductMetricsRepository {
     ProductMetrics upsertSalesCount(Long productId, Long amount);
     
     List<ProductMetrics> findAllByLastUpdatedDate(LocalDate date);
+    
+    // 배치 처리 메서드들
+    void incrementViewCountBatch(Long productId, int incrementCount, ZonedDateTime lastViewedAt);
+    void updateLikeCountBatch(Long productId, Long finalCount, ZonedDateTime lastLikedAt);
+    void incrementSalesCountBatch(Long productId, int salesCount, Long totalAmount);
 }

--- a/apps/commerce-collector/src/main/java/com/loopers/domain/repository/RankingCacheRepository.java
+++ b/apps/commerce-collector/src/main/java/com/loopers/domain/repository/RankingCacheRepository.java
@@ -1,0 +1,10 @@
+package com.loopers.domain.repository;
+
+import java.time.Duration;
+
+public interface RankingCacheRepository {
+    void addOrUpdateScore(String key, String member, double score);
+    void incrementScore(String key, String member, double score);
+    void unionAndStore(String sourceKey, String destinationKey);
+    void expire(String key, Duration ttl);
+}

--- a/apps/commerce-collector/src/main/java/com/loopers/event/BaseEvent.java
+++ b/apps/commerce-collector/src/main/java/com/loopers/event/BaseEvent.java
@@ -1,0 +1,19 @@
+package com.loopers.event;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.ZonedDateTime;
+
+@Getter
+@RequiredArgsConstructor
+public abstract class BaseEvent {
+    
+    private final String eventId;
+    private final ZonedDateTime occurredAt;
+    
+    protected BaseEvent(String eventId) {
+        this.eventId = eventId;
+        this.occurredAt = ZonedDateTime.now();
+    }
+}

--- a/apps/commerce-collector/src/main/java/com/loopers/event/LikeChangedEvent.java
+++ b/apps/commerce-collector/src/main/java/com/loopers/event/LikeChangedEvent.java
@@ -1,0 +1,27 @@
+package com.loopers.event;
+
+import lombok.Getter;
+
+import java.time.ZonedDateTime;
+
+@Getter
+public class LikeChangedEvent extends BaseEvent {
+
+    private final Long productId;
+    private final String userId;
+    private final String changeType; // LIKE or UNLIKE
+    private final int oldLikeCount;
+    private final int newLikeCount;
+    private final int version;
+
+    public LikeChangedEvent(String eventId, Long productId, String userId, String changeType,
+                           int oldLikeCount, int newLikeCount, int version, ZonedDateTime occurredAt) {
+        super(eventId, occurredAt);
+        this.productId = productId;
+        this.userId = userId;
+        this.changeType = changeType;
+        this.oldLikeCount = oldLikeCount;
+        this.newLikeCount = newLikeCount;
+        this.version = version;
+    }
+}

--- a/apps/commerce-collector/src/main/java/com/loopers/event/OrderCreatedEvent.java
+++ b/apps/commerce-collector/src/main/java/com/loopers/event/OrderCreatedEvent.java
@@ -4,6 +4,7 @@ import lombok.Getter;
 
 import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
+import java.util.List;
 
 @Getter
 public class OrderCreatedEvent extends BaseEvent {
@@ -13,14 +14,33 @@ public class OrderCreatedEvent extends BaseEvent {
     private final String userId;
     private final int totalAmount;
     private final LocalDateTime orderDate;
+    private final List<OrderItemInfo> orderItems;
 
     public OrderCreatedEvent(String eventId, Long orderId, String orderNumber, String userId,
-                           int totalAmount, LocalDateTime orderDate, ZonedDateTime occurredAt) {
+                           int totalAmount, LocalDateTime orderDate, List<OrderItemInfo> orderItems, ZonedDateTime occurredAt) {
         super(eventId, occurredAt);
         this.orderId = orderId;
         this.orderNumber = orderNumber;
         this.userId = userId;
         this.totalAmount = totalAmount;
         this.orderDate = orderDate;
+        this.orderItems = orderItems;
+    }
+
+    @Getter
+    public static class OrderItemInfo {
+        private final Long productId;
+        private final String productName;
+        private final int price;
+        private final int quantity;
+        private final int itemTotalAmount;
+
+        public OrderItemInfo(Long productId, String productName, int price, int quantity, int itemTotalAmount) {
+            this.productId = productId;
+            this.productName = productName;
+            this.price = price;
+            this.quantity = quantity;
+            this.itemTotalAmount = itemTotalAmount;
+        }
     }
 }

--- a/apps/commerce-collector/src/main/java/com/loopers/event/OrderCreatedEvent.java
+++ b/apps/commerce-collector/src/main/java/com/loopers/event/OrderCreatedEvent.java
@@ -1,0 +1,26 @@
+package com.loopers.event;
+
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
+
+@Getter
+public class OrderCreatedEvent extends BaseEvent {
+
+    private final Long orderId;
+    private final String orderNumber;
+    private final String userId;
+    private final int totalAmount;
+    private final LocalDateTime orderDate;
+
+    public OrderCreatedEvent(String eventId, Long orderId, String orderNumber, String userId,
+                           int totalAmount, LocalDateTime orderDate, ZonedDateTime occurredAt) {
+        super(eventId, occurredAt);
+        this.orderId = orderId;
+        this.orderNumber = orderNumber;
+        this.userId = userId;
+        this.totalAmount = totalAmount;
+        this.orderDate = orderDate;
+    }
+}

--- a/apps/commerce-collector/src/main/java/com/loopers/event/ProductViewedEvent.java
+++ b/apps/commerce-collector/src/main/java/com/loopers/event/ProductViewedEvent.java
@@ -1,0 +1,18 @@
+package com.loopers.event;
+
+import lombok.Getter;
+
+import java.time.ZonedDateTime;
+
+@Getter
+public class ProductViewedEvent extends BaseEvent {
+
+    private final Long productId;
+    private final String userId;
+
+    public ProductViewedEvent(String eventId, Long productId, String userId, ZonedDateTime occurredAt) {
+        super(eventId, occurredAt);
+        this.productId = productId;
+        this.userId = userId;
+    }
+}

--- a/apps/commerce-collector/src/main/java/com/loopers/event/StockAdjustedEvent.java
+++ b/apps/commerce-collector/src/main/java/com/loopers/event/StockAdjustedEvent.java
@@ -1,0 +1,25 @@
+package com.loopers.event;
+
+import lombok.Getter;
+
+import java.time.ZonedDateTime;
+
+@Getter
+public class StockAdjustedEvent extends BaseEvent {
+
+    private final Long productId;
+    private final int oldStock;
+    private final int newStock;
+    private final int adjustmentAmount;
+    private final String adjustmentReason;
+
+    public StockAdjustedEvent(String eventId, Long productId, int oldStock, int newStock,
+                            int adjustmentAmount, String adjustmentReason, ZonedDateTime occurredAt) {
+        super(eventId, occurredAt);
+        this.productId = productId;
+        this.oldStock = oldStock;
+        this.newStock = newStock;
+        this.adjustmentAmount = adjustmentAmount;
+        this.adjustmentReason = adjustmentReason;
+    }
+}

--- a/apps/commerce-collector/src/main/java/com/loopers/infrastructure/event/ConsumerEventMapper.java
+++ b/apps/commerce-collector/src/main/java/com/loopers/infrastructure/event/ConsumerEventMapper.java
@@ -1,0 +1,58 @@
+package com.loopers.infrastructure.event;
+
+import com.loopers.event.*;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
+import java.util.Map;
+
+@Component
+public class ConsumerEventMapper {
+
+    public ProductViewedEvent toProductViewedEvent(Map<String, Object> eventData) {
+        return new ProductViewedEvent(
+                (String) eventData.get("eventId"),
+                (Long) eventData.get("productId"),
+                (String) eventData.get("userId"),
+                (ZonedDateTime) eventData.get("occurredAt")
+        );
+    }
+
+    public LikeChangedEvent toLikeChangedEvent(Map<String, Object> eventData) {
+        return new LikeChangedEvent(
+                (String) eventData.get("eventId"),
+                (Long) eventData.get("productId"),
+                (String) eventData.get("userId"),
+                (String) eventData.get("changeType"),
+                (Integer) eventData.get("oldLikeCount"),
+                (Integer) eventData.get("newLikeCount"),
+                (Integer) eventData.get("version"),
+                (ZonedDateTime) eventData.get("occurredAt")
+        );
+    }
+
+    public OrderCreatedEvent toOrderCreatedEvent(Map<String, Object> eventData) {
+        return new OrderCreatedEvent(
+                (String) eventData.get("eventId"),
+                (Long) eventData.get("orderId"),
+                (String) eventData.get("orderNumber"),
+                (String) eventData.get("userId"),
+                (Integer) eventData.get("totalAmount"),
+                (LocalDateTime) eventData.get("orderDate"),
+                (ZonedDateTime) eventData.get("occurredAt")
+        );
+    }
+
+    public StockAdjustedEvent toStockAdjustedEvent(Map<String, Object> eventData) {
+        return new StockAdjustedEvent(
+                (String) eventData.get("eventId"),
+                (Long) eventData.get("productId"),
+                (Integer) eventData.get("oldStock"),
+                (Integer) eventData.get("newStock"),
+                (Integer) eventData.get("adjustmentAmount"),
+                (String) eventData.get("adjustmentReason"),
+                (ZonedDateTime) eventData.get("occurredAt")
+        );
+    }
+}

--- a/apps/commerce-collector/src/main/java/com/loopers/infrastructure/event/ProductMetricsJpaRepository.java
+++ b/apps/commerce-collector/src/main/java/com/loopers/infrastructure/event/ProductMetricsJpaRepository.java
@@ -4,9 +4,13 @@ import com.loopers.domain.entity.ProductMetrics;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Component;
 
+import java.time.ZonedDateTime;
+import java.util.List;
 import java.util.Optional;
 
 @Component
 public interface ProductMetricsJpaRepository extends JpaRepository<ProductMetrics, Long> {
     Optional<ProductMetrics> findByProductId(Long productId);
+    
+    List<ProductMetrics> findAllByUpdatedAtBetween(ZonedDateTime startDate, ZonedDateTime endDate);
 }

--- a/apps/commerce-collector/src/main/java/com/loopers/infrastructure/event/ProductMetricsRepositoryImpl.java
+++ b/apps/commerce-collector/src/main/java/com/loopers/infrastructure/event/ProductMetricsRepositoryImpl.java
@@ -5,8 +5,12 @@ import com.loopers.domain.repository.ProductMetricsRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.time.LocalDate;
 import java.time.ZonedDateTime;
+import java.util.List;
 import java.util.Optional;
+
+import static java.time.ZoneId.systemDefault;
 
 @Component
 @RequiredArgsConstructor
@@ -40,5 +44,22 @@ public class ProductMetricsRepositoryImpl implements ProductMetricsRepository {
 
         metrics.updateLikeCount(newLikeCount, likedAt);
         return save(metrics);
+    }
+    
+    @Override
+    public ProductMetrics upsertSalesCount(Long productId, Long amount) {
+        ProductMetrics metrics = findByProductId(productId)
+                .orElse(ProductMetrics.of(productId));
+        
+        metrics.incrementSalesCount(amount);
+        return save(metrics);
+    }
+    
+    @Override
+    public List<ProductMetrics> findAllByLastUpdatedDate(LocalDate date) {
+        return jpaRepository.findAllByUpdatedAtBetween(
+            date.atStartOfDay().atZone(systemDefault()),
+            date.plusDays(1).atStartOfDay().atZone(systemDefault())
+        );
     }
 }

--- a/apps/commerce-collector/src/main/java/com/loopers/infrastructure/event/ProductMetricsRepositoryImpl.java
+++ b/apps/commerce-collector/src/main/java/com/loopers/infrastructure/event/ProductMetricsRepositoryImpl.java
@@ -5,9 +5,12 @@ import com.loopers.domain.repository.ProductMetricsRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.time.LocalDate;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Optional;
+
+import static java.time.ZoneId.systemDefault;
 
 @Component
 @RequiredArgsConstructor
@@ -60,7 +63,10 @@ public class ProductMetricsRepositoryImpl implements ProductMetricsRepository {
     }
 
     @Override
-    public List<ProductMetrics> findAll() {
-        return jpaRepository.findAll();
+    public List<ProductMetrics> findAllByLastUpdatedDate(LocalDate date) {
+        return jpaRepository.findAllByUpdatedAtBetween(
+            date.atStartOfDay().atZone(systemDefault()),
+            date.plusDays(1).atStartOfDay().atZone(systemDefault())
+        );
     }
 }

--- a/apps/commerce-collector/src/main/java/com/loopers/infrastructure/event/ProductMetricsRepositoryImpl.java
+++ b/apps/commerce-collector/src/main/java/com/loopers/infrastructure/event/ProductMetricsRepositoryImpl.java
@@ -5,12 +5,9 @@ import com.loopers.domain.repository.ProductMetricsRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
-import java.time.LocalDate;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Optional;
-
-import static java.time.ZoneId.systemDefault;
 
 @Component
 @RequiredArgsConstructor
@@ -28,41 +25,6 @@ public class ProductMetricsRepositoryImpl implements ProductMetricsRepository {
         return jpaRepository.save(productMetrics);
     }
 
-    @Override
-    public ProductMetrics upsertViewCount(Long productId, ZonedDateTime viewedAt) {
-        ProductMetrics metrics = findByProductId(productId)
-                .orElse(ProductMetrics.of(productId));
-
-        metrics.incrementViewCount(viewedAt);
-        return save(metrics);
-    }
-
-    @Override
-    public ProductMetrics upsertLikeCount(Long productId, Long newLikeCount, ZonedDateTime likedAt) {
-        ProductMetrics metrics = findByProductId(productId)
-                .orElse(ProductMetrics.of(productId));
-
-        metrics.updateLikeCount(newLikeCount, likedAt);
-        return save(metrics);
-    }
-    
-    @Override
-    public ProductMetrics upsertSalesCount(Long productId, Long amount) {
-        ProductMetrics metrics = findByProductId(productId)
-                .orElse(ProductMetrics.of(productId));
-        
-        metrics.incrementSalesCount(amount);
-        return save(metrics);
-    }
-    
-    @Override
-    public List<ProductMetrics> findAllByLastUpdatedDate(LocalDate date) {
-        return jpaRepository.findAllByUpdatedAtBetween(
-            date.atStartOfDay().atZone(systemDefault()),
-            date.plusDays(1).atStartOfDay().atZone(systemDefault())
-        );
-    }
-    
     @Override
     public void incrementViewCountBatch(Long productId, int incrementCount, ZonedDateTime lastViewedAt) {
         ProductMetrics metrics = findByProductId(productId)
@@ -95,5 +57,10 @@ public class ProductMetricsRepositoryImpl implements ProductMetricsRepository {
             metrics.incrementSalesCount(avgAmount);
         }
         save(metrics);
+    }
+
+    @Override
+    public List<ProductMetrics> findAll() {
+        return jpaRepository.findAll();
     }
 }

--- a/apps/commerce-collector/src/main/java/com/loopers/infrastructure/event/ProductMetricsRepositoryImpl.java
+++ b/apps/commerce-collector/src/main/java/com/loopers/infrastructure/event/ProductMetricsRepositoryImpl.java
@@ -62,4 +62,38 @@ public class ProductMetricsRepositoryImpl implements ProductMetricsRepository {
             date.plusDays(1).atStartOfDay().atZone(systemDefault())
         );
     }
+    
+    @Override
+    public void incrementViewCountBatch(Long productId, int incrementCount, ZonedDateTime lastViewedAt) {
+        ProductMetrics metrics = findByProductId(productId)
+                .orElse(ProductMetrics.of(productId));
+        
+        // 기존 조회수에 증가분 추가
+        for (int i = 0; i < incrementCount; i++) {
+            metrics.incrementViewCount(lastViewedAt);
+        }
+        save(metrics);
+    }
+    
+    @Override
+    public void updateLikeCountBatch(Long productId, Long finalCount, ZonedDateTime lastLikedAt) {
+        ProductMetrics metrics = findByProductId(productId)
+                .orElse(ProductMetrics.of(productId));
+        
+        metrics.updateLikeCount(finalCount, lastLikedAt);
+        save(metrics);
+    }
+    
+    @Override
+    public void incrementSalesCountBatch(Long productId, int salesCount, Long totalAmount) {
+        ProductMetrics metrics = findByProductId(productId)
+                .orElse(ProductMetrics.of(productId));
+        
+        // 판매 건수와 금액을 증가분만큼 추가
+        for (int i = 0; i < salesCount; i++) {
+            long avgAmount = totalAmount / salesCount;
+            metrics.incrementSalesCount(avgAmount);
+        }
+        save(metrics);
+    }
 }

--- a/apps/commerce-collector/src/main/java/com/loopers/infrastructure/redis/RankingRedisCacheRepository.java
+++ b/apps/commerce-collector/src/main/java/com/loopers/infrastructure/redis/RankingRedisCacheRepository.java
@@ -1,0 +1,35 @@
+package com.loopers.infrastructure.redis;
+
+import com.loopers.domain.repository.RankingCacheRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+@Component
+@RequiredArgsConstructor
+public class RankingRedisCacheRepository implements RankingCacheRepository {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    @Override
+    public void addOrUpdateScore(String key, String member, double score) {
+        redisTemplate.opsForZSet().add(key, member, score);
+    }
+
+    @Override
+    public void incrementScore(String key, String member, double score) {
+        redisTemplate.opsForZSet().incrementScore(key, member, score);
+    }
+
+    @Override
+    public void unionAndStore(String sourceKey, String destinationKey) {
+        redisTemplate.opsForZSet().unionAndStore(sourceKey, destinationKey, destinationKey);
+    }
+
+    @Override
+    public void expire(String key, Duration ttl) {
+        redisTemplate.expire(key, ttl);
+    }
+}

--- a/apps/commerce-collector/src/main/java/com/loopers/infrastructure/scheduler/RankingScheduler.java
+++ b/apps/commerce-collector/src/main/java/com/loopers/infrastructure/scheduler/RankingScheduler.java
@@ -1,0 +1,65 @@
+package com.loopers.infrastructure.scheduler;
+
+import com.loopers.application.event.RankingCacheService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RankingScheduler {
+
+    private final RankingCacheService rankingCacheService;
+
+    /**
+     * 매일 자정에 전날 랭킹을 DB에서 Redis로 동기화
+     */
+    @Scheduled(cron = "0 0 0 * * ?")
+    public void syncDailyRanking() {
+        LocalDate yesterday = LocalDate.now().minusDays(1);
+        
+        try {
+            log.info("일일 랭킹 동기화 스케줄 실행 - Date: {}", yesterday);
+            rankingCacheService.syncRankingFromDatabase(yesterday);
+            log.info("일일 랭킹 동기화 스케줄 완료 - Date: {}", yesterday);
+        } catch (Exception e) {
+            log.error("일일 랭킹 동기화 스케줄 실패 - Date: {}, Error: {}", yesterday, e.getMessage(), e);
+        }
+    }
+
+    /**
+     * 매시간 정각에 오늘 랭킹을 DB에서 Redis로 동기화
+     */
+    @Scheduled(cron = "0 0 * * * ?")
+    public void syncHourlyRanking() {
+        LocalDate today = LocalDate.now();
+        
+        try {
+            log.info("시간별 랭킹 동기화 스케줄 실행 - Date: {}", today);
+            rankingCacheService.syncRankingFromDatabase(today);
+            log.info("시간별 랭킹 동기화 스케줄 완료 - Date: {}", today);
+        } catch (Exception e) {
+            log.error("시간별 랭킹 동기화 스케줄 실패 - Date: {}, Error: {}", today, e.getMessage(), e);
+        }
+    }
+
+    /**
+     * 매 5분마다 오늘 랭킹을 DB에서 Redis로 동기화
+     */
+    @Scheduled(fixedDelay = 300000) // 5분
+    public void syncRealtimeRanking() {
+        LocalDate today = LocalDate.now();
+        
+        try {
+            log.debug("실시간 랭킹 동기화 스케줄 실행 - Date: {}", today);
+            rankingCacheService.syncRankingFromDatabase(today);
+            log.debug("실시간 랭킹 동기화 스케줄 완료 - Date: {}", today);
+        } catch (Exception e) {
+            log.error("실시간 랭킹 동기화 스케줄 실패 - Date: {}, Error: {}", today, e.getMessage(), e);
+        }
+    }
+}

--- a/apps/commerce-collector/src/main/java/com/loopers/interfaces/consumer/CacheInvalidationConsumer.java
+++ b/apps/commerce-collector/src/main/java/com/loopers/interfaces/consumer/CacheInvalidationConsumer.java
@@ -4,7 +4,7 @@ import com.loopers.application.event.CacheInvalidationApplicationService;
 import com.loopers.config.kafka.KafkaConfig;
 import com.loopers.event.LikeChangedEvent;
 import com.loopers.event.StockAdjustedEvent;
-import com.loopers.infrastructure.event.ConsumerEventMapper;
+import com.loopers.application.event.ConsumerEventMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;

--- a/apps/commerce-collector/src/main/java/com/loopers/interfaces/consumer/CacheInvalidationConsumer.java
+++ b/apps/commerce-collector/src/main/java/com/loopers/interfaces/consumer/CacheInvalidationConsumer.java
@@ -4,6 +4,7 @@ import com.loopers.application.event.CacheInvalidationApplicationService;
 import com.loopers.config.kafka.KafkaConfig;
 import com.loopers.event.LikeChangedEvent;
 import com.loopers.event.StockAdjustedEvent;
+import com.loopers.infrastructure.event.ConsumerEventMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
@@ -21,6 +22,7 @@ import java.util.Map;
 public class CacheInvalidationConsumer {
 
     private final CacheInvalidationApplicationService cacheInvalidationService;
+    private final ConsumerEventMapper eventMapper;
 
     /**
      * 재고 조정 이벤트 처리 - 재고 소진 시 캐시 무효화
@@ -31,10 +33,11 @@ public class CacheInvalidationConsumer {
             containerFactory = KafkaConfig.BATCH_LISTENER
     )
     public void handleStockAdjustedEvent(
-            @Payload StockAdjustedEvent event,
+            @Payload Map<String, Object> eventData,
             @Header Map<String, Object> headers,
             Acknowledgment ack
     ) {
+        StockAdjustedEvent event = eventMapper.toStockAdjustedEvent(eventData);
         Long offset = (Long) headers.get(KafkaHeaders.OFFSET);
         Integer partition = (Integer) headers.get(KafkaHeaders.RECEIVED_PARTITION);
 
@@ -58,14 +61,15 @@ public class CacheInvalidationConsumer {
      * 좋아요 변경 이벤트 처리 - 좋아요 수 변경 시 캐시 무효화
      */
     @KafkaListener(
-            topics = "like-events",
+            topics = "${kafka.topics.like-events}",
             groupId = "cache-invalidation-group",
             containerFactory = KafkaConfig.BATCH_LISTENER
     )
     public void handleLikeChangedEvent(
-            @Payload LikeChangedEvent event,
+            @Payload Map<String, Object> eventData,
             Acknowledgment ack
     ) {
+        LikeChangedEvent event = eventMapper.toLikeChangedEvent(eventData);
         log.info("좋아요 변경 이벤트 수신 - EventId: {}, ProductId: {}",
                 event.getEventId(), event.getProductId());
 

--- a/apps/commerce-collector/src/main/java/com/loopers/interfaces/consumer/MetricsConsumer.java
+++ b/apps/commerce-collector/src/main/java/com/loopers/interfaces/consumer/MetricsConsumer.java
@@ -5,11 +5,14 @@ import com.loopers.config.kafka.KafkaConfig;
 import com.loopers.event.LikeChangedEvent;
 import com.loopers.event.OrderCreatedEvent;
 import com.loopers.event.ProductViewedEvent;
+import com.loopers.infrastructure.event.ConsumerEventMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.messaging.handler.annotation.Payload;
+
+import java.util.Map;
 import org.springframework.stereotype.Component;
 
 @Slf4j
@@ -18,6 +21,7 @@ import org.springframework.stereotype.Component;
 public class MetricsConsumer {
 
     private final MetricsApplicationService metricsService;
+    private final ConsumerEventMapper eventMapper;
 
     /**
      * 상품 조회 이벤트 처리 - 조회수 메트릭 업데이트
@@ -28,9 +32,10 @@ public class MetricsConsumer {
             containerFactory = KafkaConfig.BATCH_LISTENER
     )
     public void handleProductViewedEvent(
-            @Payload ProductViewedEvent event,
+            @Payload Map<String, Object> eventData,
             Acknowledgment ack
     ) {
+        ProductViewedEvent event = eventMapper.toProductViewedEvent(eventData);
         log.debug("상품 조회 이벤트 수신 - EventId: {}, ProductId: {}",
                 event.getEventId(), event.getProductId());
 
@@ -54,9 +59,10 @@ public class MetricsConsumer {
             containerFactory = KafkaConfig.BATCH_LISTENER
     )
     public void handleLikeChangedEvent(
-            @Payload LikeChangedEvent event,
+            @Payload Map<String, Object> eventData,
             Acknowledgment ack
     ) {
+        LikeChangedEvent event = eventMapper.toLikeChangedEvent(eventData);
         log.debug("좋아요 변경 이벤트 수신 - EventId: {}, ProductId: {}",
                 event.getEventId(), event.getProductId());
 
@@ -80,9 +86,10 @@ public class MetricsConsumer {
             containerFactory = KafkaConfig.BATCH_LISTENER
     )
     public void handleOrderCreatedEvent(
-            @Payload OrderCreatedEvent event,
+            @Payload Map<String, Object> eventData,
             Acknowledgment ack
     ) {
+        OrderCreatedEvent event = eventMapper.toOrderCreatedEvent(eventData);
         log.debug("주문 생성 이벤트 수신 - EventId: {}, OrderId: {}",
                 event.getEventId(), event.getOrderId());
         try {

--- a/apps/commerce-collector/src/main/java/com/loopers/interfaces/scheduler/RankingScheduler.java
+++ b/apps/commerce-collector/src/main/java/com/loopers/interfaces/scheduler/RankingScheduler.java
@@ -1,4 +1,4 @@
-package com.loopers.infrastructure.scheduler;
+package com.loopers.interfaces.scheduler;
 
 import com.loopers.application.event.RankingCacheService;
 import lombok.RequiredArgsConstructor;


### PR DESCRIPTION
## 📌 Summary
### 변경사항
- 메트릭 컨슈머로 받는 이벤트 강화 (주문아이템 리스트 추가 등) : [apps/commerce-api/src/main/java/com/loopers/domain/order/event/OrderCreatedEvent.java](https://github.com/maiorem/e-commerce/pull/44/files#diff-0291848b72731c359d3c2ee69b8848b321485f0342395007c9a7e1e2a364b533)
- 메트릭 컨슈머 강화 (배치처리) 
    - [apps/commerce-collector/src/main/java/com/loopers/interfaces/consumer/MetricsConsumer.java](https://github.com/maiorem/e-commerce/pull/44/files#diff-d1d750d17bdbd286ab7825a2f071128c2989404161db77e74773d2ba6df4e4a8)
    - [apps/commerce-collector/src/main/java/com/loopers/application/event/MetricsApplicationService.java](https://github.com/maiorem/e-commerce/pull/44/files#diff-86081b358882ffaa8a31e934a8e9ff75f7e54d048fc483fc89243819ae0b3aeb)
- product_metrics 테이블에 적재된 집계 데이터를 redis zset에 한번에 업데이트 
    - [apps/commerce-collector/src/main/java/com/loopers/interfaces/scheduler/RankingScheduler.java](https://github.com/maiorem/e-commerce/pull/44/files#diff-2274206924f14f2fef443d4a9e360428e0e41cbd08b0f7b106b27138e0c6d401)
- 랭킹 API 및 상품 상세에 상품 랭킹 정보 추가
    - [apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1Controller.java](https://github.com/maiorem/e-commerce/pull/44/files#diff-68877abd5d649f49edcfae7ce47ba9283d6a8919d1eb278412b4f5388e75bd4c)
    - [apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/ProductV1Controller.java](https://github.com/maiorem/e-commerce/pull/44/files#diff-0803cdd569d855b62ea6b25fff9ba6aff99405b2071e9991f9626aa61177d858)
 


## 💬 Review Points
### 집계 데이터 적재 설계 및 콜드 스타트 방지
현재, 별도의 랭킹 처리를 위한 컨슈머는 만들지 않고 MetricsConsumer로 받은 이벤트를 배치처리 후 Product_Metircs 테이블에 적재했고
이후 스케쥴러로 일정 시간에 이 테이블의 정보를 Redis ZSET 에 업데이트 하였습니다. 여기서 콜드스타트를 방지하기 위해 23시 50분에 오늘자 데이터를 내일 날짜로 웜업해두고 자정 1분에 새로운 랭킹으로 업데이트 하는 방식을 선택했습니다.
- [MetricsConsumer.java](https://github.com/maiorem/e-commerce/pull/44/files#diff-d1d750d17bdbd286ab7825a2f071128c2989404161db77e74773d2ba6df4e4a8)
- [MetricsApplicationService.java](https://github.com/maiorem/e-commerce/pull/44/files#diff-86081b358882ffaa8a31e934a8e9ff75f7e54d048fc483fc89243819ae0b3aeb)
- [RankingScheduler.java](https://github.com/maiorem/e-commerce/pull/44/files#diff-2274206924f14f2fef443d4a9e360428e0e41cbd08b0f7b106b27138e0c6d401)

이 구조가 데이터의 영속성과 안정성을 보장하는 데는 유리하지만, '실시간' 랭킹이라는 요구사항을 충족하기에는 하루라는 지연이 발생할 수 있을 것 같습니다. 그렇다고 랭킹을 위한 컨슈머를 따로 생성하여 바로 Redis 에 적재하기에는 유실 가능성이 크다고 생각했습니다. 인기상품 랭킹 목록을 위한 집계가 서비스에서 가장 중요한 기능은 아니지만 비즈니스와 마케팅에 꽤 주요한 기능일 수 있을 것 같은데 어떻게 트레이드 오프를 가져가야 할까요?

### 가중치 계산
좋아요와 조회수는 각각 Score 1씩, 주문은 price*amount에 log10 계산으로 정규화 하였습니다.
멘토링 중 말씀하신 min/max 정규화를 사용해 보려고 했으나 관련된 지식과 공부가 더 필요한 것 같아 우선 빠르게 적용 가능 한 것부터 적용했습니다. +1은 totalSalesAmount가 0인 경우 log10(0) 이 되어 오류가 발생하지 않도록 한 방지책입니다.
```
double calculateRankingScore(ProductMetrics metrics) {
    double viewScore = VIEW_WEIGHT * metrics.getViewCount();
    double likeScore = LIKE_WEIGHT * metrics.getLikeCount();
    double orderScore = ORDER_WEIGHT * Math.log10(metrics.getTotalSalesAmount() + 1);
    return viewScore + likeScore + orderScore;
}
```
가격이 그대로 Score에 반영되면 가격이 높을 수록 인기 상품 최상위에 들어가겠지만 log 정규화를 이용하면
```
log10(1,000,000 + 1)은 약 6점
log10(100,000 + 1)은 약 5점
```
이런 식으로 가격으로 인한 격차를 좁혔습니다.



## ✅ Checklist
### 📈 Ranking Consumer

- [x]  랭킹 ZSET 의 TTL, 키 전략을 적절하게 구성하였다
- [x]  날짜별로 적재할 키를 계산하는 기능을 만들었다
- [x]  이벤트가 발생한 후, ZSET 에 점수가 적절하게 반영된다

### ⚾ Ranking API

- [x]  랭킹 Page 조회 시 정상적으로 랭킹 정보가 반환된다
- [x]  랭킹 Page 조회 시 단순히 상품 ID 가 아닌 상품정보가 Aggregation 되어 제공된다
- [x]  상품 상세 조회 시 해당 상품의 순위가 함께 반환된다 (순위에 없다면 null)

## 📎 References
<!--
  (Optional: 참고 자료가 없는 작업 - 단순 버그 픽스 등 의 경우엔 해당 란을 제거해주세요 !)
  리뷰어가 참고할 수 있는 추가적인 정보나 문서, 링크 등을 작성해주세요.
  예시:
  - 관련 문서 링크
  - 관련 정책 링크
-->